### PR TITLE
Add plugin system, frontmatter editor, and webhooks

### DIFF
--- a/tibok/CLAUDE.md
+++ b/tibok/CLAUDE.md
@@ -79,7 +79,11 @@ user_docs/
     ├── workspace.md             # File/folder management
     ├── preview.md               # Preview features
     ├── find-replace.md          # Find and replace
-    └── keyboard-shortcuts.md    # Shortcut reference
+    ├── keyboard-shortcuts.md    # Shortcut reference
+    ├── git-integration.md       # Git version control
+    ├── frontmatter.md           # Jekyll/Hugo metadata editor
+    ├── plugins.md               # Plugin management
+    └── webhooks.md              # HTTP webhook notifications
 ```
 
 ### When to Update Docs
@@ -125,10 +129,14 @@ Before completing any feature work, verify:
 - Dark/light mode support
 - Print support (⌘P)
 - Math/LaTeX rendering (bundled KaTeX)
+- Frontmatter editor (⌘I) for Jekyll/Hugo metadata
+- Plugin system with enable/disable support
+- Webhook system for triggering external services
+- Focus mode (Ctrl+⌘+.)
+- Translucent macOS sidebar styling
 
 ### Planned (see planning/ folder)
 - Cloud sync
-- Plugin system
 
 ## Notes for Claude
 

--- a/tibok/progress/2025-12-15_progress.md
+++ b/tibok/progress/2025-12-15_progress.md
@@ -1,0 +1,52 @@
+# Progress Notes - December 15, 2025
+
+## Session: Plugin System Phase 1
+
+### Features Implemented
+
+#### Plugin System Core
+- **TibokPlugin protocol** - Extended with `icon` and `author` properties
+- **PluginManager** - Added enable/disable/reload functionality
+- **PluginStateManager** - New singleton for persisting plugin enabled state
+- **PluginContext** - Provides registries to plugins during registration
+
+#### Plugin Settings UI
+- **PluginSettingsView** - New Settings tab for managing plugins
+- Shows all available plugins with name, description, version, author
+- Toggle switch to enable/disable each plugin
+- State persists across app restarts via UserDefaults
+
+#### Command Registry Enhancement
+- Added `source` field to `Command` struct for tracking origin
+- Added `unregister(source:)` method to remove all commands from a plugin
+- Enables clean plugin unloading without orphaned commands
+
+#### Syntax Highlighting Fix
+- Fixed heading "shudder" when typing
+- Changed from font-based highlighting to color-only
+- Uses in-place attribute updates (`addAttributes()`) instead of string replacement
+- No layout recalculation triggered during highlighting
+
+### New Files Created
+- `tibok/Plugins/PluginStateManager.swift` - Plugin state persistence
+- `tibok/Views/PluginSettingsView.swift` - Settings UI for plugins
+
+### Files Modified
+- `tibok/Plugins/TibokPlugin.swift` - Added icon, author properties with defaults
+- `tibok/Plugins/PluginManager.swift` - Enable/disable logic, availablePluginTypes tracking
+- `tibok/Plugins/Builtin/CoreSlashCommandsPlugin.swift` - Added icon and author values
+- `tibok/Models/AppState.swift` - Command source tracking, unregister method
+- `tibok/Views/SettingsView.swift` - Added Plugins tab (5th tab)
+- `tibok/Services/SyntaxHighlighter.swift` - Color-only highlighting to fix flicker
+
+### Documentation Updates
+- Created `user_docs/features/plugins.md` - Plugin management documentation
+- Updated `user_docs/README.md` - Added Plugins link to features list
+- Updated `planning/roadmap.md` - Marked Plugin Phase 1 as complete
+
+### Technical Notes
+- Plugins are compile-time only (no dynamic loading yet)
+- Default behavior: all plugins enabled unless explicitly disabled
+- Disabled plugins stored in `disabledPlugins` UserDefaults key
+- Plugin unload removes from both SlashCommandRegistry and CommandRegistry
+- Settings window size increased to 480x400 to accommodate new tab

--- a/tibok/tibok/Models/Frontmatter.swift
+++ b/tibok/tibok/Models/Frontmatter.swift
@@ -1,0 +1,536 @@
+//
+//  Frontmatter.swift
+//  tibok
+//
+//  Parses and generates Jekyll/Hugo frontmatter (YAML and TOML).
+//
+
+import Foundation
+
+// MARK: - Frontmatter Format
+
+enum FrontmatterFormat: String, CaseIterable {
+    case yaml   // Jekyll/Hugo YAML (---)
+    case toml   // Hugo TOML (+++)
+    case none
+
+    var delimiter: String {
+        switch self {
+        case .yaml: return "---"
+        case .toml: return "+++"
+        case .none: return ""
+        }
+    }
+}
+
+// MARK: - Frontmatter Value
+
+enum FrontmatterValue: Equatable {
+    case string(String)
+    case bool(Bool)
+    case date(Date)
+    case array([String])
+    case number(Double)
+
+    var stringValue: String? {
+        if case .string(let s) = self { return s }
+        return nil
+    }
+
+    var boolValue: Bool? {
+        if case .bool(let b) = self { return b }
+        return nil
+    }
+
+    var dateValue: Date? {
+        if case .date(let d) = self { return d }
+        return nil
+    }
+
+    var arrayValue: [String]? {
+        if case .array(let a) = self { return a }
+        return nil
+    }
+
+    var numberValue: Double? {
+        if case .number(let n) = self { return n }
+        return nil
+    }
+}
+
+// MARK: - Frontmatter
+
+struct Frontmatter {
+    var format: FrontmatterFormat
+    var fields: [String: FrontmatterValue]
+    var rawString: String
+    var includeDateWithTime: Bool = false  // Whether to include time when formatting date
+    var timezoneIdentifier: String = ""    // Timezone for date formatting (empty = system default)
+
+    // MARK: - Common Fields (convenience accessors)
+
+    var title: String? {
+        get { fields["title"]?.stringValue }
+        set { fields["title"] = newValue.map { .string($0) } }
+    }
+
+    var date: Date? {
+        get { fields["date"]?.dateValue }
+        set { fields["date"] = newValue.map { .date($0) } }
+    }
+
+    var tags: [String] {
+        get { fields["tags"]?.arrayValue ?? [] }
+        set { fields["tags"] = .array(newValue) }
+    }
+
+    var categories: [String] {
+        get { fields["categories"]?.arrayValue ?? [] }
+        set { fields["categories"] = .array(newValue) }
+    }
+
+    var layout: String? {
+        get { fields["layout"]?.stringValue }
+        set { fields["layout"] = newValue.map { .string($0) } }
+    }
+
+    var draft: Bool {
+        get { fields["draft"]?.boolValue ?? false }
+        set { fields["draft"] = .bool(newValue) }
+    }
+
+    var author: String? {
+        get { fields["author"]?.stringValue }
+        set { fields["author"] = newValue.map { .string($0) } }
+    }
+
+    var description: String? {
+        get { fields["description"]?.stringValue }
+        set { fields["description"] = newValue.map { .string($0) } }
+    }
+
+    // MARK: - Initialization
+
+    init(format: FrontmatterFormat = .yaml, fields: [String: FrontmatterValue] = [:], rawString: String = "") {
+        self.format = format
+        self.fields = fields
+        self.rawString = rawString
+    }
+
+    // MARK: - Parsing
+
+    /// Parse frontmatter from markdown content.
+    /// Returns the parsed frontmatter (if any) and the body content without frontmatter.
+    static func parse(from content: String) -> (frontmatter: Frontmatter?, body: String) {
+        let trimmed = content.trimmingCharacters(in: .whitespaces)
+
+        // Try YAML (---)
+        if trimmed.hasPrefix("---") {
+            if let result = parseDelimited(content: content, delimiter: "---", format: .yaml) {
+                return result
+            }
+        }
+
+        // Try TOML (+++)
+        if trimmed.hasPrefix("+++") {
+            if let result = parseDelimited(content: content, delimiter: "+++", format: .toml) {
+                return result
+            }
+        }
+
+        // No frontmatter
+        return (nil, content)
+    }
+
+    private static func parseDelimited(content: String, delimiter: String, format: FrontmatterFormat) -> (frontmatter: Frontmatter?, body: String)? {
+        let lines = content.components(separatedBy: .newlines)
+
+        // Find opening delimiter
+        guard let firstLine = lines.first?.trimmingCharacters(in: .whitespaces),
+              firstLine == delimiter else {
+            return nil
+        }
+
+        // Find closing delimiter
+        var closingIndex: Int?
+        for (index, line) in lines.enumerated() where index > 0 {
+            if line.trimmingCharacters(in: .whitespaces) == delimiter {
+                closingIndex = index
+                break
+            }
+        }
+
+        guard let endIndex = closingIndex else {
+            return nil // No closing delimiter
+        }
+
+        // Extract frontmatter content
+        let frontmatterLines = lines[1..<endIndex]
+        let rawString = frontmatterLines.joined(separator: "\n")
+
+        // Extract body (everything after closing delimiter)
+        let bodyLines = lines[(endIndex + 1)...]
+        let body = bodyLines.joined(separator: "\n").trimmingCharacters(in: .newlines)
+
+        // Parse fields based on format
+        let fields: [String: FrontmatterValue]
+        switch format {
+        case .yaml:
+            fields = parseYAML(rawString)
+        case .toml:
+            fields = parseTOML(rawString)
+        case .none:
+            fields = [:]
+        }
+
+        let frontmatter = Frontmatter(format: format, fields: fields, rawString: rawString)
+        return (frontmatter, body)
+    }
+
+    // MARK: - YAML Parsing (simple implementation)
+
+    private static func parseYAML(_ yaml: String) -> [String: FrontmatterValue] {
+        var fields: [String: FrontmatterValue] = [:]
+        let lines = yaml.components(separatedBy: .newlines)
+
+        var currentKey: String?
+        var arrayValues: [String] = []
+        var inArray = false
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Skip empty lines and comments
+            if trimmed.isEmpty || trimmed.hasPrefix("#") {
+                continue
+            }
+
+            // Array item (starts with -)
+            if trimmed.hasPrefix("- ") && inArray, let key = currentKey {
+                let value = String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+                arrayValues.append(value)
+                continue
+            }
+
+            // Save previous array if we were collecting one
+            if inArray, let key = currentKey, !arrayValues.isEmpty {
+                fields[key] = .array(arrayValues)
+                arrayValues = []
+                inArray = false
+            }
+
+            // Key: value pair
+            if let colonIndex = trimmed.firstIndex(of: ":") {
+                let key = String(trimmed[..<colonIndex]).trimmingCharacters(in: .whitespaces)
+                let valueStr = String(trimmed[trimmed.index(after: colonIndex)...]).trimmingCharacters(in: .whitespaces)
+
+                currentKey = key
+
+                if valueStr.isEmpty {
+                    // Could be an array starting on next line
+                    inArray = true
+                    arrayValues = []
+                } else if valueStr.hasPrefix("[") && valueStr.hasSuffix("]") {
+                    // Inline array: [tag1, tag2]
+                    let inner = String(valueStr.dropFirst().dropLast())
+                    let items = inner.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+                    fields[key] = .array(items)
+                    inArray = false
+                } else {
+                    // Single value
+                    fields[key] = parseYAMLValue(valueStr)
+                    inArray = false
+                }
+            }
+        }
+
+        // Save final array if any
+        if inArray, let key = currentKey, !arrayValues.isEmpty {
+            fields[key] = .array(arrayValues)
+        }
+
+        return fields
+    }
+
+    private static func parseYAMLValue(_ value: String) -> FrontmatterValue {
+        // Remove quotes if present
+        var cleaned = value
+        if (cleaned.hasPrefix("\"") && cleaned.hasSuffix("\"")) ||
+           (cleaned.hasPrefix("'") && cleaned.hasSuffix("'")) {
+            cleaned = String(cleaned.dropFirst().dropLast())
+            return .string(cleaned)
+        }
+
+        // Boolean
+        if cleaned.lowercased() == "true" { return .bool(true) }
+        if cleaned.lowercased() == "false" { return .bool(false) }
+
+        // Date (ISO 8601 or common formats)
+        if let date = parseDate(cleaned) {
+            return .date(date)
+        }
+
+        // Number
+        if let number = Double(cleaned) {
+            return .number(number)
+        }
+
+        // Default to string
+        return .string(cleaned)
+    }
+
+    // MARK: - TOML Parsing (simple implementation)
+
+    private static func parseTOML(_ toml: String) -> [String: FrontmatterValue] {
+        var fields: [String: FrontmatterValue] = [:]
+        let lines = toml.components(separatedBy: .newlines)
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Skip empty lines and comments
+            if trimmed.isEmpty || trimmed.hasPrefix("#") {
+                continue
+            }
+
+            // Key = value pair
+            if let equalsIndex = trimmed.firstIndex(of: "=") {
+                let key = String(trimmed[..<equalsIndex]).trimmingCharacters(in: .whitespaces)
+                let valueStr = String(trimmed[trimmed.index(after: equalsIndex)...]).trimmingCharacters(in: .whitespaces)
+
+                fields[key] = parseTOMLValue(valueStr)
+            }
+        }
+
+        return fields
+    }
+
+    private static func parseTOMLValue(_ value: String) -> FrontmatterValue {
+        var cleaned = value
+
+        // String (double quotes)
+        if cleaned.hasPrefix("\"") && cleaned.hasSuffix("\"") {
+            cleaned = String(cleaned.dropFirst().dropLast())
+            return .string(cleaned)
+        }
+
+        // Array
+        if cleaned.hasPrefix("[") && cleaned.hasSuffix("]") {
+            let inner = String(cleaned.dropFirst().dropLast())
+            let items = inner.components(separatedBy: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .map { item -> String in
+                    var s = item
+                    if (s.hasPrefix("\"") && s.hasSuffix("\"")) {
+                        s = String(s.dropFirst().dropLast())
+                    }
+                    return s
+                }
+            return .array(items)
+        }
+
+        // Boolean
+        if cleaned.lowercased() == "true" { return .bool(true) }
+        if cleaned.lowercased() == "false" { return .bool(false) }
+
+        // Date
+        if let date = parseDate(cleaned) {
+            return .date(date)
+        }
+
+        // Number
+        if let number = Double(cleaned) {
+            return .number(number)
+        }
+
+        return .string(cleaned)
+    }
+
+    // MARK: - Date Parsing
+
+    private static func parseDate(_ string: String) -> Date? {
+        let formatters: [DateFormatter] = {
+            let formats = [
+                "yyyy-MM-dd",
+                "yyyy-MM-dd HH:mm:ss",
+                "yyyy-MM-dd'T'HH:mm:ss",
+                "yyyy-MM-dd'T'HH:mm:ssZ",
+                "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+            ]
+            return formats.map { format in
+                let formatter = DateFormatter()
+                formatter.dateFormat = format
+                formatter.locale = Locale(identifier: "en_US_POSIX")
+                return formatter
+            }
+        }()
+
+        for formatter in formatters {
+            if let date = formatter.date(from: string) {
+                return date
+            }
+        }
+
+        // Try ISO8601DateFormatter
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = isoFormatter.date(from: string) {
+            return date
+        }
+
+        isoFormatter.formatOptions = [.withInternetDateTime]
+        return isoFormatter.date(from: string)
+    }
+
+    // MARK: - Serialization
+
+    /// Convert frontmatter back to string representation.
+    func toString() -> String {
+        switch format {
+        case .yaml:
+            return toYAMLString()
+        case .toml:
+            return toTOMLString()
+        case .none:
+            return ""
+        }
+    }
+
+    private func toYAMLString() -> String {
+        var lines: [String] = ["---"]
+
+        // Write fields in a consistent order
+        let orderedKeys = ["title", "date", "author", "layout", "draft", "description", "tags", "categories"]
+        var writtenKeys = Set<String>()
+
+        // Write ordered keys first
+        for key in orderedKeys {
+            if let value = fields[key] {
+                lines.append(formatYAMLField(key: key, value: value))
+                writtenKeys.insert(key)
+            }
+        }
+
+        // Write remaining custom fields
+        for (key, value) in fields where !writtenKeys.contains(key) {
+            lines.append(formatYAMLField(key: key, value: value))
+        }
+
+        lines.append("---")
+        return lines.joined(separator: "\n")
+    }
+
+    private func formatYAMLField(key: String, value: FrontmatterValue) -> String {
+        switch value {
+        case .string(let s):
+            // Quote if contains special characters
+            if s.contains(":") || s.contains("#") || s.contains("\"") || s.hasPrefix(" ") {
+                return "\(key): \"\(s.replacingOccurrences(of: "\"", with: "\\\""))\""
+            }
+            return "\(key): \(s)"
+        case .bool(let b):
+            return "\(key): \(b)"
+        case .date(let d):
+            return "\(key): \(formatDateString(d))"
+        case .array(let arr):
+            if arr.isEmpty { return "\(key): []" }
+            return "\(key): [\(arr.joined(separator: ", "))]"
+        case .number(let n):
+            if n == floor(n) {
+                return "\(key): \(Int(n))"
+            }
+            return "\(key): \(n)"
+        }
+    }
+
+    private func toTOMLString() -> String {
+        var lines: [String] = ["+++"]
+
+        // Write fields in a consistent order
+        let orderedKeys = ["title", "date", "author", "layout", "draft", "description", "tags", "categories"]
+        var writtenKeys = Set<String>()
+
+        for key in orderedKeys {
+            if let value = fields[key] {
+                lines.append(formatTOMLField(key: key, value: value))
+                writtenKeys.insert(key)
+            }
+        }
+
+        for (key, value) in fields where !writtenKeys.contains(key) {
+            lines.append(formatTOMLField(key: key, value: value))
+        }
+
+        lines.append("+++")
+        return lines.joined(separator: "\n")
+    }
+
+    private func formatTOMLField(key: String, value: FrontmatterValue) -> String {
+        switch value {
+        case .string(let s):
+            return "\(key) = \"\(s.replacingOccurrences(of: "\"", with: "\\\""))\""
+        case .bool(let b):
+            return "\(key) = \(b)"
+        case .date(let d):
+            return "\(key) = \(formatDateString(d))"
+        case .array(let arr):
+            let quoted = arr.map { "\"\($0)\"" }
+            return "\(key) = [\(quoted.joined(separator: ", "))]"
+        case .number(let n):
+            if n == floor(n) {
+                return "\(key) = \(Int(n))"
+            }
+            return "\(key) = \(n)"
+        }
+    }
+
+    // MARK: - Date Formatting
+
+    /// Format a date with timezone support.
+    /// Returns ISO 8601 format when time is included, simple date otherwise.
+    private func formatDateString(_ date: Date) -> String {
+        let tz: TimeZone
+        if !timezoneIdentifier.isEmpty, let customTZ = TimeZone(identifier: timezoneIdentifier) {
+            tz = customTZ
+        } else {
+            tz = TimeZone.current
+        }
+
+        if includeDateWithTime {
+            // Full ISO 8601 with timezone: 2025-01-15T10:30:00+08:00
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            formatter.timeZone = tz
+            return formatter.string(from: date)
+        } else {
+            // Date only: 2025-01-15
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            formatter.timeZone = tz
+            return formatter.string(from: date)
+        }
+    }
+
+    // MARK: - Document Integration
+
+    /// Update document content with modified frontmatter.
+    func apply(to content: String) -> String {
+        let (_, body) = Frontmatter.parse(from: content)
+        let frontmatterStr = toString()
+
+        if frontmatterStr.isEmpty {
+            return body
+        }
+
+        return "\(frontmatterStr)\n\n\(body)"
+    }
+
+    /// Create a new document with this frontmatter.
+    static func createDocument(frontmatter: Frontmatter, body: String) -> String {
+        let frontmatterStr = frontmatter.toString()
+        if frontmatterStr.isEmpty {
+            return body
+        }
+        return "\(frontmatterStr)\n\n\(body)"
+    }
+}

--- a/tibok/tibok/Models/WebhookConfig.swift
+++ b/tibok/tibok/Models/WebhookConfig.swift
@@ -1,0 +1,152 @@
+//
+//  WebhookConfig.swift
+//  tibok
+//
+//  Configuration model for webhooks that trigger on document events.
+//
+
+import Foundation
+
+// MARK: - HTTP Method
+
+enum HTTPMethod: String, Codable, CaseIterable {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+}
+
+// MARK: - Webhook Event
+
+enum WebhookEvent: String, Codable, CaseIterable, Identifiable {
+    case documentSave = "document.save"
+    case documentExport = "document.export"
+    case gitPush = "git.push"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .documentSave: return "Document Save"
+        case .documentExport: return "Document Export"
+        case .gitPush: return "Git Push"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .documentSave: return "Triggered when a document is saved"
+        case .documentExport: return "Triggered when exporting to PDF, HTML, etc."
+        case .gitPush: return "Triggered after pushing to remote"
+        }
+    }
+}
+
+// MARK: - Webhook Config
+
+struct WebhookConfig: Codable, Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var url: String
+    var method: HTTPMethod
+    var headers: [String: String]
+    var payloadTemplate: String?
+    var events: Set<WebhookEvent>
+    var isEnabled: Bool
+
+    init(
+        id: UUID = UUID(),
+        name: String = "",
+        url: String = "",
+        method: HTTPMethod = .post,
+        headers: [String: String] = ["Content-Type": "application/json"],
+        payloadTemplate: String? = nil,
+        events: Set<WebhookEvent> = [.documentSave],
+        isEnabled: Bool = true
+    ) {
+        self.id = id
+        self.name = name
+        self.url = url
+        self.method = method
+        self.headers = headers
+        self.payloadTemplate = payloadTemplate
+        self.events = events
+        self.isEnabled = isEnabled
+    }
+
+    /// Default payload template with common variables
+    static let defaultPayloadTemplate = """
+    {
+      "event": "{{event}}",
+      "filename": "{{filename}}",
+      "title": "{{title}}",
+      "path": "{{path}}",
+      "timestamp": "{{timestamp}}"
+    }
+    """
+
+    /// Create a new webhook with default values
+    static func new() -> WebhookConfig {
+        WebhookConfig(
+            name: "New Webhook",
+            payloadTemplate: defaultPayloadTemplate
+        )
+    }
+}
+
+// MARK: - Webhook Context
+
+/// Context passed to webhooks for variable expansion
+struct WebhookContext {
+    let event: WebhookEvent
+    let filename: String
+    let title: String?
+    let path: String
+    let content: String?
+
+    /// Expand template variables in a string
+    func expand(_ template: String) -> String {
+        var result = template
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime]
+
+        result = result.replacingOccurrences(of: "{{event}}", with: event.rawValue)
+        result = result.replacingOccurrences(of: "{{filename}}", with: filename)
+        result = result.replacingOccurrences(of: "{{title}}", with: title ?? filename)
+        result = result.replacingOccurrences(of: "{{path}}", with: path)
+        result = result.replacingOccurrences(of: "{{timestamp}}", with: dateFormatter.string(from: Date()))
+
+        if let content = content {
+            // Escape content for JSON
+            let escaped = content
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+                .replacingOccurrences(of: "\n", with: "\\n")
+                .replacingOccurrences(of: "\r", with: "\\r")
+                .replacingOccurrences(of: "\t", with: "\\t")
+            result = result.replacingOccurrences(of: "{{content}}", with: escaped)
+        } else {
+            result = result.replacingOccurrences(of: "{{content}}", with: "")
+        }
+
+        return result
+    }
+}
+
+// MARK: - Webhook Result
+
+struct WebhookResult {
+    let webhook: WebhookConfig
+    let success: Bool
+    let statusCode: Int?
+    let error: String?
+    let timestamp: Date
+
+    init(webhook: WebhookConfig, success: Bool, statusCode: Int? = nil, error: String? = nil) {
+        self.webhook = webhook
+        self.success = success
+        self.statusCode = statusCode
+        self.error = error
+        self.timestamp = Date()
+    }
+}

--- a/tibok/tibok/Plugins/Builtin/CoreSlashCommandsPlugin.swift
+++ b/tibok/tibok/Plugins/Builtin/CoreSlashCommandsPlugin.swift
@@ -1,0 +1,232 @@
+//
+//  CoreSlashCommandsPlugin.swift
+//  tibok
+//
+//  Built-in plugin providing the core slash commands.
+//
+
+import Foundation
+
+/// Built-in plugin providing the core slash commands.
+/// Migrates existing hardcoded SlashCommand.all to the registry.
+@MainActor
+final class CoreSlashCommandsPlugin: TibokPlugin {
+    static let identifier = "com.tibok.core-slash-commands"
+    static let name = "Core Slash Commands"
+    static let version = "1.0.0"
+    static let description: String? = "Provides the built-in markdown slash commands"
+    static let icon = "command"
+    static let author: String? = "tibok"
+
+    init() {}
+
+    func register(with context: PluginContext) {
+        context.slashCommandRegistry.register(Self.coreCommands)
+    }
+
+    func deactivate() {
+        // Core commands stay loaded - this is a built-in plugin
+    }
+
+    // MARK: - Core Commands Definition
+
+    private static var coreCommands: [SlashCommand] {
+        [
+            // MARK: Headings
+            SlashCommand(
+                id: "h1", name: "Heading 1", description: "Large heading",
+                icon: "textformat.size.larger", insert: "# {{CURSOR}}",
+                source: identifier, keywords: ["title", "header"], category: .headings
+            ),
+            SlashCommand(
+                id: "h2", name: "Heading 2", description: "Medium heading",
+                icon: "textformat.size", insert: "## {{CURSOR}}",
+                source: identifier, keywords: ["subtitle", "header"], category: .headings
+            ),
+            SlashCommand(
+                id: "h3", name: "Heading 3", description: "Small heading",
+                icon: "textformat.size.smaller", insert: "### {{CURSOR}}",
+                source: identifier, keywords: ["header"], category: .headings
+            ),
+            SlashCommand(
+                id: "h4", name: "Heading 4", description: "Smaller heading",
+                icon: "textformat.size.smaller", insert: "#### {{CURSOR}}",
+                source: identifier, keywords: ["header"], category: .headings
+            ),
+            SlashCommand(
+                id: "h5", name: "Heading 5", description: "Small heading",
+                icon: "textformat.size.smaller", insert: "##### {{CURSOR}}",
+                source: identifier, keywords: ["header"], category: .headings
+            ),
+            SlashCommand(
+                id: "h6", name: "Heading 6", description: "Smallest heading",
+                icon: "textformat.size.smaller", insert: "###### {{CURSOR}}",
+                source: identifier, keywords: ["header"], category: .headings
+            ),
+
+            // MARK: Blocks
+            SlashCommand(
+                id: "table", name: "Table", description: "Insert table",
+                icon: "tablecells", insert: "| {{CURSOR}} | Column 2 | Column 3 |\n|----------|----------|----------|\n| Cell 1   | Cell 2   | Cell 3   |\n",
+                source: identifier, keywords: ["grid", "columns"], category: .blocks
+            ),
+            SlashCommand(
+                id: "code", name: "Code Block", description: "Fenced code block",
+                icon: "chevron.left.forwardslash.chevron.right", insert: "```{{CURSOR}}\n\n```",
+                source: identifier, keywords: ["syntax", "pre", "snippet"], category: .blocks
+            ),
+            SlashCommand(
+                id: "quote", name: "Blockquote", description: "Quote block",
+                icon: "text.quote", insert: "> {{CURSOR}}",
+                source: identifier, keywords: ["citation"], category: .blocks
+            ),
+            SlashCommand(
+                id: "callout", name: "Callout", description: "Note or warning block",
+                icon: "exclamationmark.bubble", insert: "> [!NOTE]\n> {{CURSOR}}",
+                source: identifier, keywords: ["note", "warning", "tip", "important", "caution"], category: .blocks
+            ),
+            SlashCommand(
+                id: "collapse", name: "Collapsible", description: "Expandable section",
+                icon: "chevron.down.circle", insert: "<details>\n<summary>{{CURSOR}}</summary>\n\n</details>",
+                source: identifier, keywords: ["details", "accordion", "expand"], category: .blocks
+            ),
+            SlashCommand(
+                id: "definition", name: "Definition List", description: "Term and definition",
+                icon: "list.bullet.rectangle", insert: "{{CURSOR}}\n: Definition here",
+                source: identifier, keywords: ["term", "glossary"], category: .blocks
+            ),
+
+            // MARK: Links & Media
+            SlashCommand(
+                id: "link", name: "Link", description: "Insert hyperlink",
+                icon: "link", insert: "[{{CURSOR}}](url)",
+                source: identifier, keywords: ["url", "href", "anchor"], category: .links
+            ),
+            SlashCommand(
+                id: "image", name: "Image", description: "Insert image",
+                icon: "photo", insert: "![{{CURSOR}}](image-url)",
+                source: identifier, keywords: ["picture", "photo", "img"], category: .links
+            ),
+            SlashCommand(
+                id: "footnote", name: "Footnote", description: "Add footnote reference",
+                icon: "text.append", insert: "[^{{CURSOR}}]",
+                source: identifier, keywords: ["reference", "note"], category: .links
+            ),
+
+            // MARK: Lists
+            SlashCommand(
+                id: "list", name: "Bullet List", description: "Unordered list",
+                icon: "list.bullet", insert: "- {{CURSOR}}\n- \n- \n",
+                source: identifier, keywords: ["unordered", "bullets"], category: .lists
+            ),
+            SlashCommand(
+                id: "numbered", name: "Numbered List", description: "Ordered list",
+                icon: "list.number", insert: "1. {{CURSOR}}\n2. \n3. \n",
+                source: identifier, keywords: ["ordered", "numbers"], category: .lists
+            ),
+            SlashCommand(
+                id: "task", name: "Task List", description: "Checkbox list",
+                icon: "checklist", insert: "- [ ] {{CURSOR}}\n- [ ] \n- [ ] \n",
+                source: identifier, keywords: ["todo", "checkbox", "checklist"], category: .lists
+            ),
+
+            // MARK: Formatting
+            SlashCommand(
+                id: "bold", name: "Bold", description: "Bold text",
+                icon: "bold", insert: "**{{CURSOR}}**",
+                source: identifier, keywords: ["strong"], category: .formatting
+            ),
+            SlashCommand(
+                id: "italic", name: "Italic", description: "Italic text",
+                icon: "italic", insert: "*{{CURSOR}}*",
+                source: identifier, keywords: ["emphasis", "em"], category: .formatting
+            ),
+            SlashCommand(
+                id: "bolditalic", name: "Bold Italic", description: "Bold and italic text",
+                icon: "bold.italic.underline", insert: "***{{CURSOR}}***",
+                source: identifier, keywords: ["strong emphasis"], category: .formatting
+            ),
+            SlashCommand(
+                id: "strikethrough", name: "Strikethrough", description: "Crossed out text",
+                icon: "strikethrough", insert: "~~{{CURSOR}}~~",
+                source: identifier, keywords: ["delete", "cross"], category: .formatting
+            ),
+            SlashCommand(
+                id: "underline", name: "Underline", description: "Underlined text",
+                icon: "underline", insert: "<u>{{CURSOR}}</u>",
+                source: identifier, keywords: [], category: .formatting
+            ),
+            SlashCommand(
+                id: "inlinecode", name: "Inline Code", description: "Code snippet",
+                icon: "chevron.left.forwardslash.chevron.right", insert: "`{{CURSOR}}`",
+                source: identifier, keywords: ["monospace", "backtick"], category: .formatting
+            ),
+            SlashCommand(
+                id: "highlight", name: "Highlight", description: "Highlighted text",
+                icon: "highlighter", insert: "=={{CURSOR}}==",
+                source: identifier, keywords: ["mark", "yellow"], category: .formatting
+            ),
+            SlashCommand(
+                id: "subscript", name: "Subscript", description: "Subscript text (H₂O)",
+                icon: "textformat.subscript", insert: "~{{CURSOR}}~",
+                source: identifier, keywords: ["sub", "below"], category: .formatting
+            ),
+            SlashCommand(
+                id: "superscript", name: "Superscript", description: "Superscript text (x²)",
+                icon: "textformat.superscript", insert: "^{{CURSOR}}^",
+                source: identifier, keywords: ["sup", "above", "power"], category: .formatting
+            ),
+
+            // MARK: Math
+            SlashCommand(
+                id: "math", name: "Math Inline", description: "Inline LaTeX formula",
+                icon: "function", insert: "${{CURSOR}}$",
+                source: identifier, keywords: ["latex", "equation", "formula"], category: .math
+            ),
+            SlashCommand(
+                id: "mathblock", name: "Math Block", description: "Display LaTeX formula",
+                icon: "function", insert: "$$\n{{CURSOR}}\n$$",
+                source: identifier, keywords: ["latex", "equation", "formula", "display"], category: .math
+            ),
+
+            // MARK: Structure
+            SlashCommand(
+                id: "hr", name: "Divider", description: "Horizontal rule",
+                icon: "minus", insert: "\n---\n",
+                source: identifier, keywords: ["separator", "line", "horizontal"], category: .structure
+            ),
+            SlashCommand(
+                id: "toc", name: "Table of Contents", description: "TOC placeholder",
+                icon: "list.bullet.indent", insert: "[[toc]]",
+                source: identifier, keywords: ["contents", "navigation", "outline"], category: .structure
+            ),
+
+            // MARK: Date & Time
+            SlashCommand(
+                id: "date", name: "Date", description: "Today (YYYY-MM-DD)",
+                icon: "calendar", insert: "{{DATE:yyyy-MM-dd}}",
+                source: identifier, keywords: ["today", "iso"], category: .datetime
+            ),
+            SlashCommand(
+                id: "datelong", name: "Date (Long)", description: "Today (Month Day, Year)",
+                icon: "calendar", insert: "{{DATE:MMMM d, yyyy}}",
+                source: identifier, keywords: ["today", "full"], category: .datetime
+            ),
+            SlashCommand(
+                id: "time", name: "Time", description: "Current time (HH:MM)",
+                icon: "clock", insert: "{{TIME:HH:mm}}",
+                source: identifier, keywords: ["now", "clock"], category: .datetime
+            ),
+            SlashCommand(
+                id: "datetime", name: "Date & Time", description: "Full timestamp",
+                icon: "calendar.badge.clock", insert: "{{DATE:yyyy-MM-dd}} {{TIME:HH:mm}}",
+                source: identifier, keywords: ["timestamp", "now"], category: .datetime
+            ),
+            SlashCommand(
+                id: "pickdate", name: "Pick Date", description: "Choose from calendar",
+                icon: "calendar.badge.plus", insert: "{{DATEPICKER}}",
+                source: identifier, keywords: ["choose", "select", "calendar"], category: .datetime
+            ),
+        ]
+    }
+}

--- a/tibok/tibok/Plugins/Builtin/FrontmatterPlugin.swift
+++ b/tibok/tibok/Plugins/Builtin/FrontmatterPlugin.swift
@@ -1,0 +1,83 @@
+//
+//  FrontmatterPlugin.swift
+//  tibok
+//
+//  Plugin providing frontmatter-related slash commands for Jekyll/Hugo.
+//
+
+import Foundation
+
+/// Plugin providing frontmatter slash commands for Jekyll and Hugo static site generators.
+@MainActor
+final class FrontmatterPlugin: TibokPlugin {
+    static let identifier = "com.tibok.frontmatter"
+    static let name = "Frontmatter Commands"
+    static let version = "1.0.0"
+    static let description: String? = "Slash commands for Jekyll/Hugo frontmatter"
+    static let icon = "doc.badge.gearshape"
+    static let author: String? = "tibok"
+
+    init() {}
+
+    func register(with context: PluginContext) {
+        context.slashCommandRegistry.register(Self.frontmatterCommands)
+    }
+
+    func deactivate() {
+        // Built-in plugin stays active
+    }
+
+    // MARK: - Frontmatter Commands
+
+    private static var frontmatterCommands: [SlashCommand] {
+        [
+            // Add Jekyll frontmatter
+            SlashCommand(
+                id: "frontmatter-jekyll",
+                name: "Jekyll Frontmatter",
+                description: "Add Jekyll YAML frontmatter",
+                icon: "doc.badge.gearshape",
+                insert: "{{FRONTMATTER:jekyll}}",
+                source: identifier,
+                keywords: ["yaml", "metadata", "blog", "header"],
+                category: .frontmatter
+            ),
+
+            // Add Hugo frontmatter
+            SlashCommand(
+                id: "frontmatter-hugo",
+                name: "Hugo Frontmatter",
+                description: "Add Hugo frontmatter (YAML/TOML)",
+                icon: "doc.badge.gearshape",
+                insert: "{{FRONTMATTER:hugo}}",
+                source: identifier,
+                keywords: ["toml", "yaml", "metadata", "blog", "header"],
+                category: .frontmatter
+            ),
+
+            // Toggle draft status
+            SlashCommand(
+                id: "frontmatter-draft",
+                name: "Toggle Draft",
+                description: "Toggle draft status in frontmatter",
+                icon: "doc.badge.ellipsis",
+                insert: "{{FRONTMATTER:toggle-draft}}",
+                source: identifier,
+                keywords: ["publish", "unpublish"],
+                category: .frontmatter
+            ),
+
+            // Open inspector
+            SlashCommand(
+                id: "frontmatter-inspector",
+                name: "Open Inspector",
+                description: "Open frontmatter inspector panel",
+                icon: "pencil",
+                insert: "{{FRONTMATTER:inspector}}",
+                source: identifier,
+                keywords: ["edit", "panel", "sidebar"],
+                category: .frontmatter
+            ),
+        ]
+    }
+}

--- a/tibok/tibok/Plugins/PluginContext.swift
+++ b/tibok/tibok/Plugins/PluginContext.swift
@@ -1,0 +1,32 @@
+//
+//  PluginContext.swift
+//  tibok
+//
+//  Context provided to plugins during registration.
+//
+
+import Foundation
+
+/// Context provided to plugins during registration.
+/// Provides access to registries and services plugins can extend.
+@MainActor
+final class PluginContext {
+    /// Registry for slash commands (editor inline commands)
+    let slashCommandRegistry: SlashCommandRegistry
+
+    /// Registry for command palette commands
+    let commandRegistry: CommandRegistry
+
+    /// App state for accessing document/workspace info (read-only for Phase 1)
+    weak var appState: AppState?
+
+    init(
+        slashCommandRegistry: SlashCommandRegistry,
+        commandRegistry: CommandRegistry,
+        appState: AppState?
+    ) {
+        self.slashCommandRegistry = slashCommandRegistry
+        self.commandRegistry = commandRegistry
+        self.appState = appState
+    }
+}

--- a/tibok/tibok/Plugins/PluginManager.swift
+++ b/tibok/tibok/Plugins/PluginManager.swift
@@ -1,0 +1,140 @@
+//
+//  PluginManager.swift
+//  tibok
+//
+//  Manages plugin lifecycle: discovery, initialization, and deactivation.
+//
+
+import Foundation
+
+/// Manages plugin lifecycle: discovery, initialization, and deactivation.
+@MainActor
+final class PluginManager: ObservableObject {
+    static let shared = PluginManager()
+
+    @Published private(set) var loadedPlugins: [any TibokPlugin] = []
+    @Published private(set) var pluginErrors: [String: Error] = [:]
+
+    /// All available plugin types (registered at compile time)
+    private(set) var availablePluginTypes: [any TibokPlugin.Type] = []
+
+    private var context: PluginContext?
+    private var isInitialized = false
+    private let stateManager = PluginStateManager.shared
+
+    private init() {}
+
+    /// Initialize the plugin system with required dependencies.
+    /// Call this once during app startup after AppState is created.
+    func initialize(
+        slashCommandRegistry: SlashCommandRegistry,
+        commandRegistry: CommandRegistry,
+        appState: AppState
+    ) {
+        guard !isInitialized else { return }
+        isInitialized = true
+
+        self.context = PluginContext(
+            slashCommandRegistry: slashCommandRegistry,
+            commandRegistry: commandRegistry,
+            appState: appState
+        )
+
+        // Register all known plugin types
+        registerPluginTypes()
+
+        // Load only enabled plugins
+        loadEnabledPlugins()
+    }
+
+    /// Register all known plugin types.
+    private func registerPluginTypes() {
+        availablePluginTypes = [
+            CoreSlashCommandsPlugin.self,
+            FrontmatterPlugin.self,
+        ]
+    }
+
+    /// Load only plugins that are enabled
+    private func loadEnabledPlugins() {
+        guard let context = context else { return }
+
+        for pluginType in availablePluginTypes {
+            if stateManager.isEnabled(pluginType.identifier) {
+                loadPlugin(pluginType, context: context)
+            }
+        }
+    }
+
+    private func loadPlugin(_ pluginType: any TibokPlugin.Type, context: PluginContext) {
+        let identifier = pluginType.identifier
+
+        // Don't load if already loaded
+        guard !isLoaded(identifier) else { return }
+
+        let plugin = pluginType.init()
+        plugin.register(with: context)
+        loadedPlugins.append(plugin)
+        pluginErrors.removeValue(forKey: identifier)
+    }
+
+    /// Enable a plugin by identifier
+    func enablePlugin(_ identifier: String) {
+        guard let context = context else { return }
+
+        stateManager.setEnabled(identifier, true)
+
+        // Find and load the plugin type
+        if let pluginType = availablePluginTypes.first(where: { $0.identifier == identifier }) {
+            loadPlugin(pluginType, context: context)
+        }
+    }
+
+    /// Disable a plugin by identifier
+    func disablePlugin(_ identifier: String) {
+        stateManager.setEnabled(identifier, false)
+        unloadPlugin(identifier)
+    }
+
+    /// Unload a plugin and remove its contributions
+    func unloadPlugin(_ identifier: String) {
+        guard let index = loadedPlugins.firstIndex(where: {
+            type(of: $0).identifier == identifier
+        }) else { return }
+
+        let plugin = loadedPlugins[index]
+
+        // Deactivate and remove from registries
+        plugin.deactivate()
+        context?.slashCommandRegistry.unregister(source: identifier)
+        context?.commandRegistry.unregister(source: identifier)
+
+        loadedPlugins.remove(at: index)
+    }
+
+    /// Deactivate all plugins (called on app termination)
+    func deactivateAll() {
+        for plugin in loadedPlugins {
+            plugin.deactivate()
+        }
+        loadedPlugins.removeAll()
+    }
+
+    /// Check if a plugin is loaded
+    func isLoaded(_ identifier: String) -> Bool {
+        loadedPlugins.contains { type(of: $0).identifier == identifier }
+    }
+
+    /// Get info about all loaded plugins
+    var pluginInfo: [(identifier: String, name: String, version: String)] {
+        loadedPlugins.map { plugin in
+            let type = type(of: plugin)
+            return (type.identifier, type.name, type.version)
+        }
+    }
+
+    /// All plugins (loaded or not) for Settings UI
+    var allPluginInfo: [(type: any TibokPlugin.Type, isLoaded: Bool)] {
+        availablePluginTypes.map { ($0, isLoaded($0.identifier)) }
+    }
+}

--- a/tibok/tibok/Plugins/PluginStateManager.swift
+++ b/tibok/tibok/Plugins/PluginStateManager.swift
@@ -1,0 +1,47 @@
+//
+//  PluginStateManager.swift
+//  tibok
+//
+//  Manages persistence for plugin enabled/disabled state.
+//
+
+import Foundation
+
+/// Manages persistence for plugin enabled/disabled state.
+@MainActor
+final class PluginStateManager: ObservableObject {
+    static let shared = PluginStateManager()
+
+    @Published var disabledPlugins: Set<String> = []
+
+    private let key = "disabledPlugins"
+
+    private init() {
+        load()
+    }
+
+    /// Check if a plugin is enabled (default is enabled)
+    func isEnabled(_ identifier: String) -> Bool {
+        !disabledPlugins.contains(identifier)
+    }
+
+    /// Set plugin enabled state
+    func setEnabled(_ identifier: String, _ enabled: Bool) {
+        if enabled {
+            disabledPlugins.remove(identifier)
+        } else {
+            disabledPlugins.insert(identifier)
+        }
+        save()
+    }
+
+    private func load() {
+        if let ids = UserDefaults.standard.stringArray(forKey: key) {
+            disabledPlugins = Set(ids)
+        }
+    }
+
+    private func save() {
+        UserDefaults.standard.set(Array(disabledPlugins), forKey: key)
+    }
+}

--- a/tibok/tibok/Plugins/SlashCommandRegistry.swift
+++ b/tibok/tibok/Plugins/SlashCommandRegistry.swift
@@ -1,0 +1,173 @@
+//
+//  SlashCommandRegistry.swift
+//  tibok
+//
+//  Registry for slash commands, mirroring CommandRegistry pattern.
+//
+
+import SwiftUI
+
+// MARK: - Slash Command Category
+
+enum SlashCommandCategory: String, CaseIterable {
+    case headings = "Headings"
+    case blocks = "Blocks"
+    case links = "Links & Media"
+    case lists = "Lists"
+    case formatting = "Formatting"
+    case math = "Math"
+    case structure = "Structure"
+    case datetime = "Date & Time"
+    case frontmatter = "Frontmatter"
+    case general = "General"
+}
+
+// MARK: - Slash Command
+
+/// A slash command that can be triggered in the editor by typing "/"
+struct SlashCommand: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let description: String
+    let icon: String
+    let insert: String
+
+    /// Source identifier (plugin ID or "builtin")
+    let source: String
+
+    /// Additional keywords for search
+    let keywords: [String]
+
+    /// Category for grouping in UI
+    let category: SlashCommandCategory
+
+    init(
+        id: String,
+        name: String,
+        description: String,
+        icon: String,
+        insert: String,
+        source: String = "builtin",
+        keywords: [String] = [],
+        category: SlashCommandCategory = .general
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.icon = icon
+        self.insert = insert
+        self.source = source
+        self.keywords = keywords
+        self.category = category
+    }
+
+    static func == (lhs: SlashCommand, rhs: SlashCommand) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+// MARK: - Slash Command Registry
+
+/// Registry for slash commands, mirroring CommandRegistry pattern.
+/// Manages all available slash commands including built-in and plugin-provided.
+@MainActor
+final class SlashCommandRegistry: ObservableObject {
+    static let shared = SlashCommandRegistry()
+
+    /// Nonisolated accessor for use from NSTextView delegates (which run on main thread)
+    nonisolated static var syncShared: SlashCommandRegistry {
+        MainActor.assumeIsolated { shared }
+    }
+
+    @Published private(set) var commands: [SlashCommand] = []
+    @Published var recentCommandIds: [String] = []
+
+    private let maxRecent = 10
+
+    private init() {
+        loadRecentCommands()
+    }
+
+    // MARK: - Registration
+
+    /// Register a single slash command
+    func register(_ command: SlashCommand) {
+        guard !commands.contains(where: { $0.id == command.id }) else {
+            // Duplicate command ID - skip
+            return
+        }
+        commands.append(command)
+    }
+
+    /// Register multiple slash commands
+    func register(_ commands: [SlashCommand]) {
+        for command in commands {
+            register(command)
+        }
+    }
+
+    /// Unregister a command by ID (for plugin deactivation)
+    func unregister(id: String) {
+        commands.removeAll { $0.id == id }
+    }
+
+    /// Unregister all commands from a specific source/plugin
+    func unregister(source: String) {
+        commands.removeAll { $0.source == source }
+    }
+
+    // MARK: - Search & Filter
+
+    /// Filter commands by query string
+    /// This is nonisolated to allow calling from non-MainActor contexts (like NSTextView delegates)
+    nonisolated func filtered(by query: String) -> [SlashCommand] {
+        // Access actor-isolated properties synchronously since we're on MainActor at runtime
+        // (NSTextView delegates run on main thread)
+        return MainActor.assumeIsolated {
+            if query.isEmpty {
+                // Return recent first, then others
+                let recentCommands = recentCommandIds.compactMap { id in
+                    commands.first { $0.id == id }
+                }
+                let otherCommands = commands.filter { !recentCommandIds.contains($0.id) }
+                return recentCommands + otherCommands
+            }
+
+            let lower = query.lowercased()
+            return commands.filter {
+                $0.id.contains(lower) ||
+                $0.name.lowercased().contains(lower) ||
+                $0.keywords.contains { $0.lowercased().contains(lower) }
+            }
+        }
+    }
+
+    /// Record command usage for recent tracking
+    /// This is nonisolated to allow calling from non-MainActor contexts
+    nonisolated func recordUsage(_ commandId: String) {
+        MainActor.assumeIsolated {
+            recentCommandIds.removeAll { $0 == commandId }
+            recentCommandIds.insert(commandId, at: 0)
+            if recentCommandIds.count > maxRecent {
+                recentCommandIds = Array(recentCommandIds.prefix(maxRecent))
+            }
+            saveRecentCommands()
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func loadRecentCommands() {
+        if let ids = UserDefaults.standard.stringArray(forKey: "recentSlashCommands") {
+            recentCommandIds = ids
+        }
+    }
+
+    private func saveRecentCommands() {
+        UserDefaults.standard.set(recentCommandIds, forKey: "recentSlashCommands")
+    }
+}

--- a/tibok/tibok/Plugins/TibokPlugin.swift
+++ b/tibok/tibok/Plugins/TibokPlugin.swift
@@ -1,0 +1,50 @@
+//
+//  TibokPlugin.swift
+//  tibok
+//
+//  Plugin protocol definition for tibok extensions.
+//
+
+import Foundation
+
+/// Protocol that all tibok plugins must implement.
+/// Plugins are Swift Package-based and loaded at compile time.
+@MainActor
+protocol TibokPlugin {
+    /// Unique identifier for the plugin (reverse-DNS style recommended)
+    static var identifier: String { get }
+
+    /// Human-readable name shown in UI
+    static var name: String { get }
+
+    /// Plugin version string
+    static var version: String { get }
+
+    /// Optional description of what the plugin does
+    static var description: String? { get }
+
+    /// SF Symbol icon name for display in settings
+    static var icon: String { get }
+
+    /// Author name
+    static var author: String? { get }
+
+    /// Initialize the plugin. Called once during app startup.
+    init()
+
+    /// Register the plugin's contributions.
+    /// Called after init, before any plugin features are used.
+    /// - Parameter context: Provides access to registries and app services
+    func register(with context: PluginContext)
+
+    /// Called when the plugin should clean up (app termination or plugin disable)
+    func deactivate()
+}
+
+// Default implementations for optional members
+extension TibokPlugin {
+    static var description: String? { nil }
+    static var icon: String { "puzzlepiece.extension" }
+    static var author: String? { nil }
+    func deactivate() {}
+}

--- a/tibok/tibok/Services/MarkdownRenderer.swift
+++ b/tibok/tibok/Services/MarkdownRenderer.swift
@@ -11,7 +11,9 @@ struct MarkdownRenderer {
 
     /// Renders markdown text to HTML
     static func render(_ markdown: String) -> String {
-        var html = markdown
+        // Strip frontmatter before processing (Jekyll/Hugo YAML/TOML)
+        let (_, body) = Frontmatter.parse(from: markdown)
+        var html = body
 
         // Process TOC placeholder - collect headers first
         let tocPlaceholder = "<!--TOC_PLACEHOLDER-->"

--- a/tibok/tibok/Services/WebhookService.swift
+++ b/tibok/tibok/Services/WebhookService.swift
@@ -1,0 +1,197 @@
+//
+//  WebhookService.swift
+//  tibok
+//
+//  Service for managing and executing webhooks.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class WebhookService: ObservableObject {
+    static let shared = WebhookService()
+
+    @Published var webhooks: [WebhookConfig] = []
+    @Published var recentResults: [WebhookResult] = []
+
+    private let userDefaultsKey = "webhooks"
+    private let maxRecentResults = 50
+
+    private init() {
+        loadWebhooks()
+    }
+
+    // MARK: - Webhook Management
+
+    func addWebhook(_ webhook: WebhookConfig) {
+        webhooks.append(webhook)
+        saveWebhooks()
+    }
+
+    func updateWebhook(_ webhook: WebhookConfig) {
+        if let index = webhooks.firstIndex(where: { $0.id == webhook.id }) {
+            webhooks[index] = webhook
+            saveWebhooks()
+        }
+    }
+
+    func deleteWebhook(_ webhook: WebhookConfig) {
+        webhooks.removeAll { $0.id == webhook.id }
+        saveWebhooks()
+    }
+
+    func deleteWebhook(at offsets: IndexSet) {
+        webhooks.remove(atOffsets: offsets)
+        saveWebhooks()
+    }
+
+    func toggleWebhook(_ webhook: WebhookConfig) {
+        if let index = webhooks.firstIndex(where: { $0.id == webhook.id }) {
+            webhooks[index].isEnabled.toggle()
+            saveWebhooks()
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func loadWebhooks() {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey) else {
+            return
+        }
+
+        do {
+            webhooks = try JSONDecoder().decode([WebhookConfig].self, from: data)
+        } catch {
+            print("Failed to load webhooks: \(error)")
+        }
+    }
+
+    private func saveWebhooks() {
+        do {
+            let data = try JSONEncoder().encode(webhooks)
+            UserDefaults.standard.set(data, forKey: userDefaultsKey)
+        } catch {
+            print("Failed to save webhooks: \(error)")
+        }
+    }
+
+    // MARK: - Event Triggering
+
+    /// Trigger all webhooks registered for the given event
+    func trigger(event: WebhookEvent, context: WebhookContext) async {
+        let enabledWebhooks = webhooks.filter { $0.isEnabled && $0.events.contains(event) }
+
+        for webhook in enabledWebhooks {
+            let result = await executeWebhook(webhook, context: context)
+            addResult(result)
+        }
+    }
+
+    /// Convenience method to trigger document save webhooks
+    func triggerDocumentSave(filename: String, title: String?, path: String, content: String? = nil) async {
+        let context = WebhookContext(
+            event: .documentSave,
+            filename: filename,
+            title: title,
+            path: path,
+            content: content
+        )
+        await trigger(event: .documentSave, context: context)
+    }
+
+    /// Convenience method to trigger document export webhooks
+    func triggerDocumentExport(filename: String, title: String?, path: String, exportFormat: String) async {
+        let context = WebhookContext(
+            event: .documentExport,
+            filename: filename,
+            title: title,
+            path: path,
+            content: nil
+        )
+        await trigger(event: .documentExport, context: context)
+    }
+
+    /// Convenience method to trigger git push webhooks
+    func triggerGitPush(repositoryPath: String) async {
+        let context = WebhookContext(
+            event: .gitPush,
+            filename: "",
+            title: nil,
+            path: repositoryPath,
+            content: nil
+        )
+        await trigger(event: .gitPush, context: context)
+    }
+
+    // MARK: - Webhook Execution
+
+    private func executeWebhook(_ webhook: WebhookConfig, context: WebhookContext) async -> WebhookResult {
+        guard let url = URL(string: webhook.url) else {
+            return WebhookResult(webhook: webhook, success: false, error: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = webhook.method.rawValue
+        request.timeoutInterval = 30
+
+        // Set headers
+        for (key, value) in webhook.headers {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+
+        // Set body for POST/PUT/DELETE
+        if webhook.method != .get, let template = webhook.payloadTemplate {
+            let payload = context.expand(template)
+            request.httpBody = payload.data(using: .utf8)
+        }
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+
+            if let httpResponse = response as? HTTPURLResponse {
+                let success = (200...299).contains(httpResponse.statusCode)
+                return WebhookResult(
+                    webhook: webhook,
+                    success: success,
+                    statusCode: httpResponse.statusCode,
+                    error: success ? nil : "HTTP \(httpResponse.statusCode)"
+                )
+            }
+
+            return WebhookResult(webhook: webhook, success: true)
+        } catch {
+            return WebhookResult(
+                webhook: webhook,
+                success: false,
+                error: error.localizedDescription
+            )
+        }
+    }
+
+    /// Test a webhook without saving it
+    func testWebhook(_ webhook: WebhookConfig) async -> WebhookResult {
+        let context = WebhookContext(
+            event: webhook.events.first ?? .documentSave,
+            filename: "test-document.md",
+            title: "Test Document",
+            path: "/path/to/test-document.md",
+            content: "This is a test webhook payload."
+        )
+
+        return await executeWebhook(webhook, context: context)
+    }
+
+    // MARK: - Results Management
+
+    private func addResult(_ result: WebhookResult) {
+        recentResults.insert(result, at: 0)
+        if recentResults.count > maxRecentResults {
+            recentResults.removeLast()
+        }
+    }
+
+    func clearResults() {
+        recentResults.removeAll()
+    }
+}

--- a/tibok/tibok/Views/EditorView.swift
+++ b/tibok/tibok/Views/EditorView.swift
@@ -125,74 +125,7 @@ class EmojiState: ObservableObject {
 }
 
 // MARK: - Slash Commands
-
-struct SlashCommand: Identifiable {
-    let id: String
-    let name: String
-    let description: String
-    let icon: String
-    let insert: String
-
-    static let all: [SlashCommand] = [
-        // Headings
-        SlashCommand(id: "h1", name: "Heading 1", description: "Large heading", icon: "textformat.size.larger", insert: "# {{CURSOR}}"),
-        SlashCommand(id: "h2", name: "Heading 2", description: "Medium heading", icon: "textformat.size", insert: "## {{CURSOR}}"),
-        SlashCommand(id: "h3", name: "Heading 3", description: "Small heading", icon: "textformat.size.smaller", insert: "### {{CURSOR}}"),
-        SlashCommand(id: "h4", name: "Heading 4", description: "Smaller heading", icon: "textformat.size.smaller", insert: "#### {{CURSOR}}"),
-        SlashCommand(id: "h5", name: "Heading 5", description: "Small heading", icon: "textformat.size.smaller", insert: "##### {{CURSOR}}"),
-        SlashCommand(id: "h6", name: "Heading 6", description: "Smallest heading", icon: "textformat.size.smaller", insert: "###### {{CURSOR}}"),
-
-        // Blocks
-        SlashCommand(id: "table", name: "Table", description: "Insert table", icon: "tablecells", insert: "| {{CURSOR}} | Column 2 | Column 3 |\n|----------|----------|----------|\n| Cell 1   | Cell 2   | Cell 3   |\n"),
-        SlashCommand(id: "code", name: "Code Block", description: "Fenced code block", icon: "chevron.left.forwardslash.chevron.right", insert: "```{{CURSOR}}\n\n```"),
-        SlashCommand(id: "quote", name: "Blockquote", description: "Quote block", icon: "text.quote", insert: "> {{CURSOR}}"),
-        SlashCommand(id: "callout", name: "Callout", description: "Note or warning block", icon: "exclamationmark.bubble", insert: "> [!NOTE]\n> {{CURSOR}}"),
-        SlashCommand(id: "collapse", name: "Collapsible", description: "Expandable section", icon: "chevron.down.circle", insert: "<details>\n<summary>{{CURSOR}}</summary>\n\n</details>"),
-        SlashCommand(id: "definition", name: "Definition List", description: "Term and definition", icon: "list.bullet.rectangle", insert: "{{CURSOR}}\n: Definition here"),
-
-        // Links & Media
-        SlashCommand(id: "link", name: "Link", description: "Insert hyperlink", icon: "link", insert: "[{{CURSOR}}](url)"),
-        SlashCommand(id: "image", name: "Image", description: "Insert image", icon: "photo", insert: "![{{CURSOR}}](image-url)"),
-        SlashCommand(id: "footnote", name: "Footnote", description: "Add footnote reference", icon: "text.append", insert: "[^{{CURSOR}}]"),
-
-        // Lists
-        SlashCommand(id: "list", name: "Bullet List", description: "Unordered list", icon: "list.bullet", insert: "- {{CURSOR}}\n- \n- \n"),
-        SlashCommand(id: "numbered", name: "Numbered List", description: "Ordered list", icon: "list.number", insert: "1. {{CURSOR}}\n2. \n3. \n"),
-        SlashCommand(id: "task", name: "Task List", description: "Checkbox list", icon: "checklist", insert: "- [ ] {{CURSOR}}\n- [ ] \n- [ ] \n"),
-
-        // Inline formatting
-        SlashCommand(id: "bold", name: "Bold", description: "Bold text", icon: "bold", insert: "**{{CURSOR}}**"),
-        SlashCommand(id: "italic", name: "Italic", description: "Italic text", icon: "italic", insert: "*{{CURSOR}}*"),
-        SlashCommand(id: "bolditalic", name: "Bold Italic", description: "Bold and italic text", icon: "bold.italic.underline", insert: "***{{CURSOR}}***"),
-        SlashCommand(id: "strikethrough", name: "Strikethrough", description: "Crossed out text", icon: "strikethrough", insert: "~~{{CURSOR}}~~"),
-        SlashCommand(id: "underline", name: "Underline", description: "Underlined text", icon: "underline", insert: "<u>{{CURSOR}}</u>"),
-        SlashCommand(id: "inlinecode", name: "Inline Code", description: "Code snippet", icon: "chevron.left.forwardslash.chevron.right", insert: "`{{CURSOR}}`"),
-        SlashCommand(id: "highlight", name: "Highlight", description: "Highlighted text", icon: "highlighter", insert: "=={{CURSOR}}=="),
-        SlashCommand(id: "subscript", name: "Subscript", description: "Subscript text (H₂O)", icon: "textformat.subscript", insert: "~{{CURSOR}}~"),
-        SlashCommand(id: "superscript", name: "Superscript", description: "Superscript text (x²)", icon: "textformat.superscript", insert: "^{{CURSOR}}^"),
-
-        // Math
-        SlashCommand(id: "math", name: "Math Inline", description: "Inline LaTeX formula", icon: "function", insert: "${{CURSOR}}$"),
-        SlashCommand(id: "mathblock", name: "Math Block", description: "Display LaTeX formula", icon: "function", insert: "$$\n{{CURSOR}}\n$$"),
-
-        // Separators & Structure
-        SlashCommand(id: "hr", name: "Divider", description: "Horizontal rule", icon: "minus", insert: "\n---\n"),
-        SlashCommand(id: "toc", name: "Table of Contents", description: "TOC placeholder", icon: "list.bullet.indent", insert: "[[toc]]"),
-
-        // Date & Time (special handling)
-        SlashCommand(id: "date", name: "Date", description: "Today (YYYY-MM-DD)", icon: "calendar", insert: "{{DATE:yyyy-MM-dd}}"),
-        SlashCommand(id: "datelong", name: "Date (Long)", description: "Today (Month Day, Year)", icon: "calendar", insert: "{{DATE:MMMM d, yyyy}}"),
-        SlashCommand(id: "time", name: "Time", description: "Current time (HH:MM)", icon: "clock", insert: "{{TIME:HH:mm}}"),
-        SlashCommand(id: "datetime", name: "Date & Time", description: "Full timestamp", icon: "calendar.badge.clock", insert: "{{DATE:yyyy-MM-dd}} {{TIME:HH:mm}}"),
-        SlashCommand(id: "pickdate", name: "Pick Date", description: "Choose from calendar", icon: "calendar.badge.plus", insert: "{{DATEPICKER}}"),
-    ]
-
-    static func filtered(by query: String) -> [SlashCommand] {
-        if query.isEmpty { return all }
-        let lower = query.lowercased()
-        return all.filter { $0.id.contains(lower) || $0.name.lowercased().contains(lower) }
-    }
-}
+// SlashCommand struct and registry now in Plugins/SlashCommandRegistry.swift
 
 // MARK: - Emoji Items
 
@@ -732,7 +665,15 @@ struct FindableTextEditor: NSViewRepresentable {
         }
 
         func showSlashMenu(at point: NSPoint, query: String, slashRange: NSRange) {
-            let commands = SlashCommand.filtered(by: query)
+            // Early exit if query hasn't changed and menu is already showing
+            // This avoids unnecessary filtering and state updates on each keystroke
+            if slashMenuWindow != nil && parent.slashState.query == query {
+                // Just update the range for insertion
+                parent.slashState.slashRange = slashRange
+                return
+            }
+
+            let commands = SlashCommandRegistry.syncShared.filtered(by: query)
             guard !commands.isEmpty else {
                 dismissSlashMenu()
                 return
@@ -775,15 +716,28 @@ struct FindableTextEditor: NSViewRepresentable {
                 slashMenuController?.updateCommands(commands, slashRange: slashRange)
             }
 
-            // Update position (below cursor)
-            slashMenuWindow?.setFrameTopLeftPoint(NSPoint(x: point.x, y: point.y - 4))
+            // Update window height based on command count and position
+            if let window = slashMenuWindow, let screen = NSScreen.main {
+                let menuHeight = min(CGFloat(commands.count * 44) + 8, 300)
+                let lineHeight: CGFloat = 20 // Approximate line height
 
-            // Update window height based on command count
-            if let window = slashMenuWindow {
+                // Check if there's enough space below the cursor
+                let spaceBelow = point.y - screen.visibleFrame.origin.y
+                let showAbove = spaceBelow < menuHeight + 20
+
                 var frame = window.frame
-                let newHeight = min(CGFloat(commands.count * 44) + 8, 300)
-                frame.origin.y += frame.size.height - newHeight
-                frame.size.height = newHeight
+                frame.size.height = menuHeight
+
+                if showAbove {
+                    // Position above the cursor
+                    frame.origin.x = point.x
+                    frame.origin.y = point.y + lineHeight
+                } else {
+                    // Position below the cursor (original behavior)
+                    frame.origin.x = point.x
+                    frame.origin.y = point.y - menuHeight - 4
+                }
+
                 window.setFrame(frame, display: true)
             }
 
@@ -793,6 +747,9 @@ struct FindableTextEditor: NSViewRepresentable {
         }
 
         func dismissSlashMenu() {
+            // Early exit if already dismissed to avoid unnecessary state updates
+            guard slashMenuWindow != nil || parent.slashState.isActive else { return }
+
             slashMenuWindow?.orderOut(nil)
             slashMenuWindow = nil
             slashMenuController = nil
@@ -810,6 +767,19 @@ struct FindableTextEditor: NSViewRepresentable {
             if insertText == "{{DATEPICKER}}" {
                 dismissSlashMenu()
                 showDatePicker(range: range)
+                return
+            }
+
+            // Handle frontmatter commands
+            if insertText.hasPrefix("{{FRONTMATTER:") {
+                dismissSlashMenu()
+                // Remove the slash command text first
+                if textView.shouldChangeText(in: range, replacementString: "") {
+                    textView.replaceCharacters(in: range, with: "")
+                    textView.didChangeText()
+                }
+                handleFrontmatterCommand(insertText)
+                SlashCommandRegistry.syncShared.recordUsage(command.id)
                 return
             }
 
@@ -867,6 +837,9 @@ struct FindableTextEditor: NSViewRepresentable {
                 }
                 textView.setSelectedRange(NSRange(location: newLocation, length: 0))
             }
+
+            // Track usage for recent commands
+            SlashCommandRegistry.syncShared.recordUsage(command.id)
 
             dismissSlashMenu()
         }
@@ -943,6 +916,133 @@ struct FindableTextEditor: NSViewRepresentable {
             }
 
             pendingDateRange = nil
+        }
+
+        // MARK: - Frontmatter Commands
+
+        func handleFrontmatterCommand(_ command: String) {
+            guard let textView = textView else { return }
+
+            // Extract the command type from {{FRONTMATTER:type}}
+            let pattern = try? NSRegularExpression(pattern: "\\{\\{FRONTMATTER:([^}]+)\\}\\}", options: [])
+            guard let match = pattern?.firstMatch(in: command, options: [], range: NSRange(command.startIndex..., in: command)),
+                  let typeRange = Range(match.range(at: 1), in: command) else { return }
+
+            let commandType = String(command[typeRange])
+
+            switch commandType {
+            case "jekyll":
+                insertJekyllFrontmatter(textView: textView)
+            case "hugo":
+                insertHugoFrontmatter(textView: textView)
+            case "toggle-draft":
+                toggleDraftStatus(textView: textView)
+            case "inspector":
+                NotificationCenter.default.post(name: .toggleInspector, object: nil)
+            default:
+                break
+            }
+        }
+
+        private func insertJekyllFrontmatter(textView: NSTextView) {
+            let content = textView.string
+            let (existingFrontmatter, _) = Frontmatter.parse(from: content)
+
+            // Don't add if frontmatter already exists
+            if existingFrontmatter != nil { return }
+
+            // Get defaults from settings
+            let jekyllAuthor = UserDefaults.standard.string(forKey: SettingsKeys.jekyllDefaultAuthor) ?? ""
+            let jekyllLayout = UserDefaults.standard.string(forKey: SettingsKeys.jekyllDefaultLayout) ?? "post"
+            let jekyllDraft = UserDefaults.standard.bool(forKey: SettingsKeys.jekyllDefaultDraft)
+            let jekyllTags = UserDefaults.standard.string(forKey: SettingsKeys.jekyllDefaultTags) ?? ""
+            let jekyllCategories = UserDefaults.standard.string(forKey: SettingsKeys.jekyllDefaultCategories) ?? ""
+
+            var fm = Frontmatter(format: .yaml)
+            // Get title from document URL or use default
+            let title = parent.documentURL()?.deletingPathExtension().lastPathComponent ?? "Untitled"
+            fm.title = title
+            fm.date = Date()
+            fm.draft = jekyllDraft
+            if !jekyllAuthor.isEmpty { fm.author = jekyllAuthor }
+            if !jekyllLayout.isEmpty { fm.layout = jekyllLayout }
+            if !jekyllTags.isEmpty {
+                fm.tags = jekyllTags.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+            }
+            if !jekyllCategories.isEmpty {
+                fm.categories = jekyllCategories.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+            }
+
+            let frontmatterStr = fm.toString() + "\n\n"
+            let range = NSRange(location: 0, length: 0)
+
+            if textView.shouldChangeText(in: range, replacementString: frontmatterStr) {
+                textView.replaceCharacters(in: range, with: frontmatterStr)
+                textView.didChangeText()
+                // Move cursor to end of frontmatter
+                textView.setSelectedRange(NSRange(location: frontmatterStr.count, length: 0))
+            }
+        }
+
+        private func insertHugoFrontmatter(textView: NSTextView) {
+            let content = textView.string
+            let (existingFrontmatter, _) = Frontmatter.parse(from: content)
+
+            // Don't add if frontmatter already exists
+            if existingFrontmatter != nil { return }
+
+            // Get defaults from settings
+            let hugoFormat = UserDefaults.standard.string(forKey: SettingsKeys.hugoDefaultFormat) ?? "yaml"
+            let hugoAuthor = UserDefaults.standard.string(forKey: SettingsKeys.hugoDefaultAuthor) ?? ""
+            let hugoLayout = UserDefaults.standard.string(forKey: SettingsKeys.hugoDefaultLayout) ?? ""
+            let hugoDraft = UserDefaults.standard.bool(forKey: SettingsKeys.hugoDefaultDraft)
+            let hugoTags = UserDefaults.standard.string(forKey: SettingsKeys.hugoDefaultTags) ?? ""
+            let hugoCategories = UserDefaults.standard.string(forKey: SettingsKeys.hugoDefaultCategories) ?? ""
+
+            let format: FrontmatterFormat = hugoFormat == "toml" ? .toml : .yaml
+            var fm = Frontmatter(format: format)
+            // Get title from document URL or use default
+            let title = parent.documentURL()?.deletingPathExtension().lastPathComponent ?? "Untitled"
+            fm.title = title
+            fm.date = Date()
+            fm.draft = hugoDraft
+            if !hugoAuthor.isEmpty { fm.author = hugoAuthor }
+            if !hugoLayout.isEmpty { fm.layout = hugoLayout }
+            if !hugoTags.isEmpty {
+                fm.tags = hugoTags.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+            }
+            if !hugoCategories.isEmpty {
+                fm.categories = hugoCategories.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+            }
+
+            let frontmatterStr = fm.toString() + "\n\n"
+            let range = NSRange(location: 0, length: 0)
+
+            if textView.shouldChangeText(in: range, replacementString: frontmatterStr) {
+                textView.replaceCharacters(in: range, with: frontmatterStr)
+                textView.didChangeText()
+                textView.setSelectedRange(NSRange(location: frontmatterStr.count, length: 0))
+            }
+        }
+
+        private func toggleDraftStatus(textView: NSTextView) {
+            let content = textView.string
+            let (frontmatter, body) = Frontmatter.parse(from: content)
+
+            guard var fm = frontmatter else { return }
+
+            // Toggle draft status
+            fm.draft = !fm.draft
+
+            // Rebuild the document
+            let newContent = fm.apply(to: body)
+
+            // Replace entire content
+            let fullRange = NSRange(location: 0, length: (content as NSString).length)
+            if textView.shouldChangeText(in: fullRange, replacementString: newContent) {
+                textView.replaceCharacters(in: fullRange, with: newContent)
+                textView.didChangeText()
+            }
         }
 
         func handleSlashMenuKeyDown(_ event: NSEvent) -> Bool {

--- a/tibok/tibok/Views/PluginSettingsView.swift
+++ b/tibok/tibok/Views/PluginSettingsView.swift
@@ -1,0 +1,114 @@
+//
+//  PluginSettingsView.swift
+//  tibok
+//
+//  Settings view for managing plugins.
+//
+
+import SwiftUI
+import AppKit
+
+/// Display info for a plugin in the settings UI
+struct PluginDisplayInfo: Identifiable {
+    let id: String
+    let identifier: String
+    let name: String
+    let version: String
+    let description: String?
+    let icon: String
+    let author: String?
+    let isLoaded: Bool
+}
+
+struct PluginSettingsView: View {
+    @ObservedObject var pluginManager = PluginManager.shared
+    @ObservedObject var stateManager = PluginStateManager.shared
+
+    private var plugins: [PluginDisplayInfo] {
+        pluginManager.availablePluginTypes.map { pluginType in
+            PluginDisplayInfo(
+                id: pluginType.identifier,
+                identifier: pluginType.identifier,
+                name: pluginType.name,
+                version: pluginType.version,
+                description: pluginType.description,
+                icon: pluginType.icon,
+                author: pluginType.author,
+                isLoaded: pluginManager.isLoaded(pluginType.identifier)
+            )
+        }
+    }
+
+    var body: some View {
+        Form {
+            Section("Installed Plugins") {
+                if plugins.isEmpty {
+                    Text("No plugins installed")
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(plugins) { plugin in
+                        PluginRow(plugin: plugin)
+                    }
+                }
+            }
+
+            Section {
+                Text("Plugins extend tibok with additional commands and features. Disable a plugin to remove its contributions.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+}
+
+struct PluginRow: View {
+    let plugin: PluginDisplayInfo
+    @ObservedObject var stateManager = PluginStateManager.shared
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: plugin.icon)
+                .font(.title2)
+                .foregroundColor(.accentColor)
+                .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(plugin.name)
+                    .fontWeight(.medium)
+                if let desc = plugin.description {
+                    Text(desc)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+                if let author = plugin.author {
+                    Text("by \(author)")
+                        .font(.caption2)
+                        .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                }
+            }
+
+            Spacer()
+
+            Text("v\(plugin.version)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Toggle("", isOn: Binding(
+                get: { stateManager.isEnabled(plugin.identifier) },
+                set: { enabled in
+                    if enabled {
+                        PluginManager.shared.enablePlugin(plugin.identifier)
+                    } else {
+                        PluginManager.shared.disablePlugin(plugin.identifier)
+                    }
+                }
+            ))
+            .toggleStyle(.switch)
+            .labelsHidden()
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/tibok/tibok/Views/PreviewView.swift
+++ b/tibok/tibok/Views/PreviewView.swift
@@ -54,22 +54,23 @@ struct PreviewView: View {
     }
 
     /// Get code theme colors based on selected theme
-    private var codeThemeCSS: (background: String, darkBackground: String) {
+    /// Returns: (lightBackground, darkBackground, lightText, darkText)
+    private var codeThemeCSS: (background: String, darkBackground: String, textColor: String, darkTextColor: String) {
         switch codeTheme {
         case "atom-one-dark":
-            return ("#282c34", "#282c34")
+            return ("#282c34", "#282c34", "#abb2bf", "#abb2bf")
         case "github":
-            return ("#f6f8fa", "#2d333b")
+            return ("#f6f8fa", "#2d333b", "#24292e", "#c9d1d9")
         case "monokai":
-            return ("#272822", "#272822")
+            return ("#272822", "#272822", "#f8f8f2", "#f8f8f2")
         case "vs":
-            return ("#ffffff", "#1e1e1e")
+            return ("#ffffff", "#1e1e1e", "#000000", "#d4d4d4")
         case "xcode":
-            return ("#ffffff", "#292a30")
+            return ("#ffffff", "#292a30", "#000000", "#ffffff")
         case "dracula":
-            return ("#282a36", "#282a36")
+            return ("#282a36", "#282a36", "#f8f8f2", "#f8f8f2")
         default:
-            return ("#f5f5f5", "#2d2d2d")
+            return ("#f5f5f5", "#2d2d2d", "#333333", "#e5e5e5")
         }
     }
 
@@ -92,6 +93,7 @@ struct PreviewView: View {
                     --preview-font-size: \(Int(fontSize))px;
                     --preview-max-width: \(maxWidthCSS);
                     --code-bg: \(themeColors.background);
+                    --code-text: \(themeColors.textColor);
                 }
                 * {
                     -webkit-user-modify: read-only !important;
@@ -116,6 +118,7 @@ struct PreviewView: View {
                 code {
                     font-family: 'SF Mono', Menlo, monospace;
                     background: var(--code-bg);
+                    color: var(--code-text);
                     padding: 2px 6px;
                     border-radius: 4px;
                     font-size: 0.875em;
@@ -132,6 +135,7 @@ struct PreviewView: View {
                     padding: 0;
                     font-size: 0.8125em;
                     line-height: 1.5;
+                    color: var(--code-text);
                 }
                 blockquote {
                     border-left: 4px solid #e5e5e5;
@@ -223,6 +227,7 @@ struct PreviewView: View {
                 @media (prefers-color-scheme: dark) {
                     :root {
                         --code-bg: \(themeColors.darkBackground);
+                        --code-text: \(themeColors.darkTextColor);
                     }
                     body { color: #e5e5e5; }
                     h1 { border-bottom-color: #3d3d3d; }

--- a/tibok/tibok/Views/SidebarView.swift
+++ b/tibok/tibok/Views/SidebarView.swift
@@ -6,6 +6,36 @@
 //
 
 import SwiftUI
+import AppKit
+
+// MARK: - Visual Effect Background
+
+/// NSVisualEffectView wrapper for SwiftUI - provides macOS translucent/vibrancy effect
+struct VisualEffectBackground: NSViewRepresentable {
+    var material: NSVisualEffectView.Material
+    var blendingMode: NSVisualEffectView.BlendingMode
+
+    init(
+        material: NSVisualEffectView.Material = .sidebar,
+        blendingMode: NSVisualEffectView.BlendingMode = .behindWindow
+    ) {
+        self.material = material
+        self.blendingMode = blendingMode
+    }
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .followsWindowActiveState
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        nsView.material = material
+        nsView.blendingMode = blendingMode
+    }
+}
 
 /// Result of searching file contents
 struct ContentSearchResult: Identifiable {
@@ -250,7 +280,7 @@ struct SidebarView: View {
                 .padding(8)
             }
         }
-        .background(Color(NSColor.controlBackgroundColor))
+        .background(VisualEffectBackground(material: .sidebar))
         .sheet(isPresented: $showNewFileSheet) {
             NewFileSheet(fileName: $newFileName) {
                 if !newFileName.isEmpty {

--- a/tibok/tibok/Views/StatusBarView.swift
+++ b/tibok/tibok/Views/StatusBarView.swift
@@ -51,10 +51,11 @@ struct StatusBarView: View {
         HStack(spacing: 0) {
             // Left side - git branch (when in git repo) or word count
             if appState.isGitRepository, let branch = appState.currentBranch {
-                HStack(spacing: 4) {
+                HStack(alignment: .center, spacing: 4) {
                     Image(systemName: "arrow.triangle.branch")
                         .font(.system(size: 10))
                         .foregroundColor(.secondary)
+                        .frame(height: 12, alignment: .center)
                     Text(branch)
                         .font(.caption)
                         .foregroundColor(.secondary)
@@ -98,7 +99,7 @@ struct StatusBarView: View {
 
             // Right side - save status (only when document open)
             if !appState.hasNoDocuments {
-                HStack(spacing: 4) {
+                HStack(alignment: .center, spacing: 4) {
                     Circle()
                         .fill(saveStatusColor)
                         .frame(width: 6, height: 6)

--- a/tibok/tibok/Views/WebhookSettingsView.swift
+++ b/tibok/tibok/Views/WebhookSettingsView.swift
@@ -1,0 +1,392 @@
+//
+//  WebhookSettingsView.swift
+//  tibok
+//
+//  Settings view for managing webhooks.
+//
+
+import SwiftUI
+
+struct WebhookSettingsView: View {
+    @ObservedObject var webhookService = WebhookService.shared
+    @State private var showAddSheet = false
+    @State private var editingWebhook: WebhookConfig?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Header
+            Text("Webhooks")
+                .font(.headline)
+
+            Text("Webhooks are HTTP requests triggered when events occur, such as saving a document or pushing to Git.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Divider()
+
+            // Webhook list
+            if webhookService.webhooks.isEmpty {
+                VStack(spacing: 8) {
+                    Text("No webhooks configured")
+                        .foregroundColor(.secondary)
+                    Button("Add Webhook") {
+                        showAddSheet = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List {
+                    ForEach(webhookService.webhooks) { webhook in
+                        WebhookRow(webhook: webhook) {
+                            editingWebhook = webhook
+                        } onToggle: {
+                            webhookService.toggleWebhook(webhook)
+                        } onDelete: {
+                            webhookService.deleteWebhook(webhook)
+                        }
+                    }
+                }
+                .listStyle(.inset)
+
+                HStack {
+                    Button {
+                        showAddSheet = true
+                    } label: {
+                        Label("Add Webhook", systemImage: "plus")
+                    }
+
+                    Spacer()
+                }
+            }
+        }
+        .padding()
+        .sheet(isPresented: $showAddSheet) {
+            WebhookEditorSheet(webhook: .new()) { newWebhook in
+                webhookService.addWebhook(newWebhook)
+            }
+        }
+        .sheet(item: $editingWebhook) { webhook in
+            WebhookEditorSheet(webhook: webhook) { updatedWebhook in
+                webhookService.updateWebhook(updatedWebhook)
+            }
+        }
+    }
+}
+
+// MARK: - Webhook Row
+
+struct WebhookRow: View {
+    let webhook: WebhookConfig
+    let onEdit: () -> Void
+    let onToggle: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(webhook.name)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(webhook.isEnabled ? .primary : .secondary)
+
+                Text(webhook.url)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+
+                HStack(spacing: 4) {
+                    Text(webhook.method.rawValue)
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(Color.accentColor.opacity(0.15))
+                        .cornerRadius(3)
+
+                    ForEach(Array(webhook.events), id: \.self) { event in
+                        Text(event.displayName)
+                            .font(.system(size: 10))
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.15))
+                            .cornerRadius(3)
+                    }
+                }
+            }
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { webhook.isEnabled },
+                set: { _ in onToggle() }
+            ))
+            .labelsHidden()
+
+            Button {
+                onEdit()
+            } label: {
+                Image(systemName: "pencil")
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                onDelete()
+            } label: {
+                Image(systemName: "trash")
+                    .foregroundColor(.red)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Webhook Editor Sheet
+
+struct WebhookEditorSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var webhook: WebhookConfig
+    @State private var testResult: WebhookResult?
+    @State private var isTesting = false
+
+    let onSave: (WebhookConfig) -> Void
+
+    init(webhook: WebhookConfig, onSave: @escaping (WebhookConfig) -> Void) {
+        _webhook = State(initialValue: webhook)
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Text(webhook.name.isEmpty ? "New Webhook" : webhook.name)
+                    .font(.headline)
+
+                Spacer()
+
+                Button("Save") {
+                    onSave(webhook)
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(webhook.name.isEmpty || webhook.url.isEmpty)
+            }
+            .padding()
+
+            Divider()
+
+            // Form
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    // Basic info
+                    GroupBox("Basic") {
+                        VStack(alignment: .leading, spacing: 12) {
+                            LabeledContent("Name") {
+                                TextField("Webhook name", text: $webhook.name)
+                                    .textFieldStyle(.roundedBorder)
+                            }
+
+                            LabeledContent("URL") {
+                                TextField("https://example.com/webhook", text: $webhook.url)
+                                    .textFieldStyle(.roundedBorder)
+                            }
+
+                            LabeledContent("Method") {
+                                Picker("", selection: $webhook.method) {
+                                    ForEach(HTTPMethod.allCases, id: \.self) { method in
+                                        Text(method.rawValue).tag(method)
+                                    }
+                                }
+                                .pickerStyle(.segmented)
+                                .frame(width: 200)
+                            }
+                        }
+                        .padding(.vertical, 8)
+                    }
+
+                    // Events
+                    GroupBox("Events") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(WebhookEvent.allCases) { event in
+                                HStack {
+                                    Toggle(isOn: Binding(
+                                        get: { webhook.events.contains(event) },
+                                        set: { isSelected in
+                                            if isSelected {
+                                                webhook.events.insert(event)
+                                            } else {
+                                                webhook.events.remove(event)
+                                            }
+                                        }
+                                    )) {
+                                        VStack(alignment: .leading, spacing: 1) {
+                                            Text(event.displayName)
+                                                .font(.system(size: 13))
+                                            Text(event.description)
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        .padding(.vertical, 8)
+                    }
+
+                    // Headers
+                    GroupBox("Headers") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(Array(webhook.headers.keys.sorted()), id: \.self) { key in
+                                HStack {
+                                    Text(key)
+                                        .font(.system(size: 12, design: .monospaced))
+                                        .frame(width: 120, alignment: .leading)
+                                    Text(webhook.headers[key] ?? "")
+                                        .font(.system(size: 12, design: .monospaced))
+                                        .foregroundColor(.secondary)
+                                    Spacer()
+                                    Button {
+                                        webhook.headers.removeValue(forKey: key)
+                                    } label: {
+                                        Image(systemName: "minus.circle.fill")
+                                            .foregroundColor(.red)
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                            }
+
+                            HeaderEditor { key, value in
+                                webhook.headers[key] = value
+                            }
+                        }
+                        .padding(.vertical, 8)
+                    }
+
+                    // Payload
+                    GroupBox("Payload Template") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            TextEditor(text: Binding(
+                                get: { webhook.payloadTemplate ?? "" },
+                                set: { webhook.payloadTemplate = $0.isEmpty ? nil : $0 }
+                            ))
+                            .font(.system(size: 12, design: .monospaced))
+                            .frame(height: 120)
+                            .border(Color.secondary.opacity(0.3))
+
+                            Text("Variables: {{event}}, {{filename}}, {{title}}, {{path}}, {{timestamp}}, {{content}}")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 8)
+                    }
+
+                    // Test
+                    GroupBox("Test") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Button {
+                                    Task {
+                                        isTesting = true
+                                        testResult = await WebhookService.shared.testWebhook(webhook)
+                                        isTesting = false
+                                    }
+                                } label: {
+                                    if isTesting {
+                                        ProgressView()
+                                            .controlSize(.small)
+                                    } else {
+                                        Text("Send Test Request")
+                                    }
+                                }
+                                .disabled(webhook.url.isEmpty || isTesting)
+
+                                Spacer()
+
+                                if let result = testResult {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: result.success ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                            .foregroundColor(result.success ? .green : .red)
+                                        if let statusCode = result.statusCode {
+                                            Text("HTTP \(statusCode)")
+                                                .font(.caption)
+                                        }
+                                        if let error = result.error, !result.success {
+                                            Text(error)
+                                                .font(.caption)
+                                                .foregroundColor(.red)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        .padding(.vertical, 8)
+                    }
+                }
+                .padding()
+            }
+        }
+        .frame(width: 500, height: 600)
+    }
+}
+
+// MARK: - Header Editor
+
+struct HeaderEditor: View {
+    @State private var key = ""
+    @State private var value = ""
+
+    let onAdd: (String, String) -> Void
+
+    var body: some View {
+        HStack {
+            TextField("Header", text: $key)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 120)
+
+            TextField("Value", text: $value)
+                .textFieldStyle(.roundedBorder)
+
+            Button {
+                if !key.isEmpty && !value.isEmpty {
+                    onAdd(key, value)
+                    key = ""
+                    value = ""
+                }
+            } label: {
+                Image(systemName: "plus.circle.fill")
+                    .foregroundColor(.green)
+            }
+            .buttonStyle(.plain)
+            .disabled(key.isEmpty || value.isEmpty)
+        }
+    }
+}
+
+// MARK: - Labeled Content Helper
+
+struct LabeledContent<Content: View>: View {
+    let label: String
+    let content: Content
+
+    init(_ label: String, @ViewBuilder content: () -> Content) {
+        self.label = label
+        self.content = content()
+    }
+
+    var body: some View {
+        HStack(alignment: .center) {
+            Text(label)
+                .frame(width: 60, alignment: .trailing)
+                .foregroundColor(.secondary)
+            content
+        }
+    }
+}

--- a/tibok/tibok/tibokApp.swift
+++ b/tibok/tibok/tibokApp.swift
@@ -42,6 +42,7 @@ struct tibokApp: App {
                 }
                 .onAppear {
                     applyAppearance()
+                    initializePlugins()
                 }
                 .onChange(of: appearanceMode) { _, _ in
                     applyAppearance()
@@ -134,6 +135,11 @@ struct tibokApp: App {
                     NotificationCenter.default.post(name: .togglePreview, object: nil)
                 }
                 .keyboardShortcut("\\", modifiers: .command)
+
+                Button("Toggle Inspector") {
+                    NotificationCenter.default.post(name: .toggleInspector, object: nil)
+                }
+                .keyboardShortcut("i", modifiers: .command)
 
                 Button("Focus Mode") {
                     NotificationCenter.default.post(name: .toggleFocusMode, object: nil)
@@ -286,6 +292,14 @@ struct tibokApp: App {
         case .dark:
             NSApp.appearance = NSAppearance(named: .darkAqua)
         }
+    }
+
+    private func initializePlugins() {
+        PluginManager.shared.initialize(
+            slashCommandRegistry: SlashCommandRegistry.shared,
+            commandRegistry: CommandRegistry.shared,
+            appState: appState
+        )
     }
 }
 

--- a/tibok/user_docs/FAQ.md
+++ b/tibok/user_docs/FAQ.md
@@ -113,11 +113,55 @@ Right-click any file in the workspace, recent files, or open tabs and select "Ad
 | Save As | Cmd+Shift+S |
 | Toggle Sidebar | Cmd+0 |
 | Toggle Preview | Cmd+\ |
+| Toggle Inspector | Cmd+I |
 | Command Palette | Cmd+K |
 | Find | Cmd+F |
 | Find and Replace | Cmd+Option+F |
 | Find Next | Cmd+G |
 | Find Previous | Cmd+Shift+G |
+
+---
+
+## Frontmatter (Inspector)
+
+### How do I edit frontmatter metadata?
+Open the Inspector panel with Cmd+I. If your document doesn't have frontmatter yet, choose Jekyll or Hugo and click "Add Frontmatter".
+
+### What frontmatter formats are supported?
+- Jekyll: YAML (`---` delimiters)
+- Hugo: YAML (`---`) or TOML (`+++`)
+
+### How do I set the timezone for dates?
+Go to Settings > Frontmatter and select your timezone from the dropdown. When using "Date & Time" mode, dates are formatted as ISO 8601 with the timezone offset.
+
+### Is frontmatter shown in the preview?
+No, frontmatter is automatically stripped from the preview so you see your content as readers will.
+
+See [Frontmatter Editor](features/frontmatter.md) for more details.
+
+---
+
+## Plugins
+
+### What are plugins?
+Plugins are extensions that add commands and features to Tibok. You can enable or disable them from Settings > Plugins.
+
+### Where are the slash commands?
+Slash commands are provided by the "Core Slash Commands" plugin. If slash commands aren't working, check Settings > Plugins to ensure it's enabled.
+
+See [Plugins](features/plugins.md) for more details.
+
+---
+
+## Webhooks
+
+### What are webhooks?
+Webhooks send HTTP requests to external services when events occur (like saving a document). This is useful for triggering builds or notifications.
+
+### How do I create a webhook?
+Go to Settings > Webhooks, click "Add Webhook", and configure the URL, events, and payload.
+
+See [Webhooks](features/webhooks.md) for more details.
 
 ---
 
@@ -144,4 +188,4 @@ Right-click any file in the workspace, recent files, or open tabs and select "Ad
 
 ### What features are coming next?
 See our roadmap for planned features:
-- **Future**: Cloud sync, plugin system, publishing integrations
+- **Future**: Cloud sync, publishing integrations

--- a/tibok/user_docs/README.md
+++ b/tibok/user_docs/README.md
@@ -9,7 +9,8 @@ Welcome to the Tibok documentation. Tibok is a native macOS markdown editor buil
 3. **Use slash commands**: Type `/` at line start for quick formatting
 4. **Open command palette**: Cmd+K for quick actions (grouped by category)
 5. **Toggle preview**: Cmd+\ to see rendered output
-6. **Save your work**: Cmd+S
+6. **Edit frontmatter**: Cmd+I to open the inspector panel
+7. **Save your work**: Cmd+S
 
 ## Interface
 
@@ -19,6 +20,7 @@ Tibok features a clean, distraction-free interface:
 - **Sidebar**: Workspace, Favorites, Recent files, plus collapsible Git panel
 - **Editor**: Full-width writing area (no header for maximum space)
 - **Preview**: Live-updating rendered markdown
+- **Inspector**: Frontmatter editor for Jekyll/Hugo metadata (Cmd+I)
 - **Status bar**: Document stats, Git branch, and helpful shortcuts
 
 ## Documentation
@@ -28,11 +30,14 @@ Tibok features a clean, distraction-free interface:
 
 ### Features
 - [Slash Commands](features/slash-commands.md) - Quick formatting with `/` commands
+- [Frontmatter Editor](features/frontmatter.md) - Jekyll/Hugo metadata editing
 - [Image Handling](features/image-handling.md) - Drag, drop, and paste images
 - [Workspace & Files](features/workspace.md) - File and folder management
 - [Git Integration](features/git-integration.md) - Version control with Git
 - [Preview](features/preview.md) - Live markdown preview
 - [Find and Replace](features/find-replace.md) - Search and replace text
+- [Plugins](features/plugins.md) - Enable/disable editor extensions
+- [Webhooks](features/webhooks.md) - HTTP notifications on events
 - [Keyboard Shortcuts](features/keyboard-shortcuts.md) - Complete shortcut reference
 
 ## Favorites

--- a/tibok/user_docs/features/frontmatter.md
+++ b/tibok/user_docs/features/frontmatter.md
@@ -1,0 +1,115 @@
+# Frontmatter Editor
+
+Tibok includes a built-in frontmatter editor for Jekyll and Hugo static site generators. The inspector panel lets you edit frontmatter metadata through a form-based interface.
+
+## Opening the Inspector
+
+- **Keyboard**: Cmd+I
+- **Menu**: View > Toggle Inspector
+- **Command Palette**: Cmd+K, then search "inspector"
+
+## Supported Formats
+
+| Generator | Format | Delimiter |
+|-----------|--------|-----------|
+| Jekyll | YAML | `---` |
+| Hugo | YAML | `---` |
+| Hugo | TOML | `+++` |
+
+## Creating Frontmatter
+
+When you open the inspector on a document without frontmatter:
+
+1. Choose your static site generator (Jekyll or Hugo)
+2. Click "Add Frontmatter"
+3. The frontmatter block is added with your default settings
+
+## Editing Fields
+
+The inspector provides form controls for common frontmatter fields:
+
+### Status
+- **Draft**: Toggle switch to mark document as unpublished
+
+### Document
+- **Title**: Document title
+- **Description**: Brief summary or excerpt
+- **Date**: Publication date picker
+- **Time**: Optional time with timezone (toggle "Date & Time" mode)
+
+### Metadata
+- **Author**: Author name
+- **Layout**: Template name (e.g., "post", "page")
+
+### Taxonomy
+- **Tags**: Comma-separated list of tags
+- **Categories**: Comma-separated list of categories
+
+### Custom Fields
+Add any additional key-value pairs your site needs.
+
+## Date and Time
+
+When "Date & Time" mode is enabled:
+- A time picker appears with your configured timezone
+- Dates are formatted as ISO 8601 with timezone offset
+- Example: `2025-01-15T10:30:00-08:00`
+
+When in "Date only" mode:
+- Dates are formatted as `2025-01-15`
+
+## Timezone Configuration
+
+Set your preferred timezone in Settings > Frontmatter:
+
+1. Open Settings (Cmd+,)
+2. Go to the Frontmatter tab
+3. Select your timezone from the dropdown
+4. All date/time values will use this timezone
+
+Common timezones included:
+- UTC
+- US timezones (Eastern, Central, Mountain, Pacific, Alaska, Hawaii)
+- European timezones (London, Paris, Berlin)
+- Asian timezones (Tokyo, Shanghai, Singapore, India)
+- Pacific timezones (Sydney, Auckland)
+
+## Default Values
+
+Configure default values for new frontmatter in Settings > Frontmatter:
+
+### Jekyll Defaults
+- Author
+- Layout (default: "post")
+- Draft status
+- Default tags
+- Default categories
+
+### Hugo Defaults
+- Frontmatter format (YAML or TOML)
+- Author
+- Layout
+- Draft status
+- Default tags
+- Default categories
+
+## Live Sync
+
+Changes in the inspector are immediately reflected in your document's frontmatter. The sync works both ways:
+- Edit in inspector → document updates
+- Edit document directly → inspector updates
+
+## Removing Frontmatter
+
+Click "Remove Frontmatter" at the bottom of the inspector to strip the frontmatter block from your document.
+
+## Preview Behavior
+
+Frontmatter is automatically hidden from the preview pane. Only the document body is rendered, so you see your content as readers will.
+
+## Tips
+
+- Use the command palette (Cmd+K) to quickly toggle the inspector
+- Set up defaults in Settings to save time on new posts
+- The inspector remembers your Jekyll/Hugo selection
+- Custom fields support any string value

--- a/tibok/user_docs/features/keyboard-shortcuts.md
+++ b/tibok/user_docs/features/keyboard-shortcuts.md
@@ -21,6 +21,7 @@ Complete reference for all keyboard shortcuts in Tibok.
 |--------|----------|
 | Toggle Sidebar | Cmd+0 |
 | Toggle Preview | Cmd+\ |
+| Toggle Inspector | Cmd+I |
 | Focus Mode | Ctrl+Cmd+. |
 | Command Palette | Cmd+K |
 | Next Tab | Cmd+Shift+] |

--- a/tibok/user_docs/features/plugins.md
+++ b/tibok/user_docs/features/plugins.md
@@ -1,0 +1,46 @@
+# Plugins
+
+Tibok supports a plugin system that allows extending the editor with additional commands and features. Plugins can be enabled or disabled from Settings.
+
+## Managing Plugins
+
+1. Open **Settings** (Cmd+,)
+2. Click the **Plugins** tab
+3. Toggle plugins on/off using the switch
+
+When you disable a plugin:
+- Its slash commands are immediately removed
+- Its command palette commands are removed
+- Changes take effect instantly (no restart required)
+
+When you enable a plugin:
+- Its commands become available immediately
+- State persists across app restarts
+
+## Built-in Plugins
+
+### Core Slash Commands
+- **Identifier**: `com.tibok.core-slash-commands`
+- **Provides**: 35+ slash commands for markdown formatting
+- **Always recommended**: This plugin provides essential editing functionality
+
+See [Slash Commands](slash-commands.md) for the full command reference.
+
+## Plugin Information
+
+Each plugin displays:
+- **Name** and **description**
+- **Version** number
+- **Author** (if provided)
+- **Icon** representing the plugin type
+
+## Troubleshooting
+
+### Slash commands not working?
+1. Open Settings > Plugins
+2. Verify "Core Slash Commands" is enabled
+3. If disabled, toggle it on
+
+### Plugin state not saving?
+- Plugin preferences are stored in UserDefaults
+- Check if you have write permissions to ~/Library/Preferences

--- a/tibok/user_docs/features/webhooks.md
+++ b/tibok/user_docs/features/webhooks.md
@@ -1,0 +1,127 @@
+# Webhooks
+
+Webhooks allow Tibok to send HTTP requests to external services when events occur, such as saving a document or pushing to Git. This is useful for triggering build pipelines, notifying services, or integrating with automation tools.
+
+## Accessing Webhooks
+
+Open Settings (Cmd+,) and navigate to the **Webhooks** tab.
+
+## Creating a Webhook
+
+1. Click **Add Webhook**
+2. Fill in the webhook details:
+   - **Name**: A descriptive name for the webhook
+   - **URL**: The endpoint to send requests to
+   - **Method**: HTTP method (GET, POST, PUT, DELETE)
+3. Select which **Events** should trigger this webhook
+4. Customize **Headers** if needed (Content-Type: application/json is set by default)
+5. Edit the **Payload Template** to customize the request body
+6. Click **Save**
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| Document Save | Triggered when a document is saved |
+| Document Export | Triggered when exporting to PDF, HTML, etc. |
+| Git Push | Triggered after pushing to a remote repository |
+
+You can select multiple events for a single webhook.
+
+## Payload Variables
+
+Use these variables in your payload template. They will be replaced with actual values when the webhook fires:
+
+| Variable | Description |
+|----------|-------------|
+| `{{event}}` | The event that triggered the webhook (e.g., `document.save`) |
+| `{{filename}}` | Name of the document file |
+| `{{title}}` | Document title (from frontmatter, or filename if not set) |
+| `{{path}}` | Full file path |
+| `{{timestamp}}` | ISO 8601 timestamp of when the event occurred |
+| `{{content}}` | Document content (JSON-escaped) |
+
+### Default Payload Template
+
+```json
+{
+  "event": "{{event}}",
+  "filename": "{{filename}}",
+  "title": "{{title}}",
+  "path": "{{path}}",
+  "timestamp": "{{timestamp}}"
+}
+```
+
+## Testing Webhooks
+
+Before relying on a webhook, test it:
+
+1. Open the webhook editor
+2. Click **Send Test Request**
+3. Check the result indicator for success/failure
+4. The test uses sample data (test-document.md)
+
+## Managing Webhooks
+
+### Enable/Disable
+
+Toggle the switch next to any webhook to enable or disable it without deleting the configuration.
+
+### Edit
+
+Click the pencil icon to modify an existing webhook.
+
+### Delete
+
+Swipe left on a webhook row or use the delete option to remove it.
+
+## Use Cases
+
+### Trigger a Jekyll/Hugo Build
+
+Send a POST request to your CI/CD service when you save a document:
+
+```json
+{
+  "event": "{{event}}",
+  "repository": "my-blog",
+  "file": "{{filename}}",
+  "timestamp": "{{timestamp}}"
+}
+```
+
+### Notify Slack
+
+Post to a Slack webhook when content is updated:
+
+```json
+{
+  "text": "Document updated: {{title}} ({{filename}})"
+}
+```
+
+### Log to a Service
+
+Send document metadata to a logging service for analytics.
+
+## Troubleshooting
+
+### Webhook not firing
+
+1. Check that the webhook is enabled (toggle is on)
+2. Verify the correct events are selected
+3. Make sure the URL is correct and accessible
+
+### Request failing
+
+1. Use the **Test** button to check connectivity
+2. Verify headers are correct for your endpoint
+3. Check that the payload template is valid JSON
+4. Review the HTTP status code in the test result
+
+### Timeout errors
+
+Webhooks have a 30-second timeout. If your endpoint is slow, consider:
+- Using an async endpoint that returns immediately
+- Optimizing the receiving service

--- a/tibok/user_docs/features/workspace.md
+++ b/tibok/user_docs/features/workspace.md
@@ -18,7 +18,7 @@ The sidebar provides quick access to your files when working with a workspace.
 
 ### Showing/Hiding
 - **Menu**: View > Toggle Sidebar
-- **Shortcut**: Cmd+Option+S
+- **Shortcut**: Cmd+0
 
 ### Sections
 


### PR DESCRIPTION
Introduces a compile-time plugin system with enable/disable support, a frontmatter inspector panel (with ⌘I shortcut), and a webhook system for document and git events. Adds new models for frontmatter and webhooks, new plugin management UI, and updates command and slash command registries to support plugin contributions and clean unloading. Syntax highlighting is improved to prevent flicker, and documentation is updated to reflect new features.