### PR TITLE
Add Package.resolved for Xcode Cloud builds

### DIFF
--- a/tibok/Package.resolved
+++ b/tibok/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raspu/Highlightr.git",
+      "state" : {
+        "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown.git",
+      "state" : {
+        "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
+        "version" : "0.7.3"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/tibok/tibok.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tibok/tibok.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "b94ac757167f1830e33bc01f8b3bc5615846833ecf598136db0b269d05da05e5",
+  "pins" : [
+    {
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raspu/Highlightr.git",
+      "state" : {
+        "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown.git",
+      "state" : {
+        "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
+        "version" : "0.7.3"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
This commit adds the Package.resolved files that lock dependency versions. These files are essential for Xcode Cloud CI/CD builds to ensure consistent dependency resolution between local and cloud builds.

Files committed:
- Package.resolved (root level)
- tibok.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved

Locked versions:
- swift-markdown: 0.7.3
- Highlightr: 2.3.0
- swift-cmark: 0.7.1 (transitive)

Without these files, Xcode Cloud fails with:
"a resolved file is required when automatic dependency resolution is disabled"

🤖 Generated with Claude Code