### PR TITLE
Fix App Store compliance issues (ITMS-90242, ITMS-90296)

### DIFF
--- a/tibok/tibok/Resources/Info.plist
+++ b/tibok/tibok/Resources/Info.plist
@@ -65,6 +65,8 @@
 	<string>/ay6S8AYXl9889RX+1pojK/3lNKgerQ7bFP5gSLUh9E=</string>
 	<key>SUScheduledCheckInterval</key>
 	<integer>86400</integer>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.productivity</string>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/tibok/tibok/Resources/tibok-dmg.entitlements
+++ b/tibok/tibok/Resources/tibok-dmg.entitlements
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
 </plist>

--- a/tibok/tibok/Resources/tibok.entitlements
+++ b/tibok/tibok/Resources/tibok.entitlements
@@ -2,5 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This commit addresses two critical App Store submission requirements:

1. ITMS-90242: Added LSApplicationCategoryType to Info.plist
   - Category: public.app-category.productivity
   - Required for all macOS App Store submissions
   - Identifies tibok as a Productivity application

2. ITMS-90296: Enabled app sandbox in entitlements
   - com.apple.security.app-sandbox = true (REQUIRED)
   - com.apple.security.files.user-selected.read-write = true (allows file opening/saving for markdown editor)
   - com.apple.security.network.client = true (allows Git operations and WordPress publishing)

Files updated:
- tibok/Resources/Info.plist
- tibok/Resources/tibok.entitlements
- tibok/Resources/tibok-dmg.entitlements

These changes ensure tibok complies with macOS App Store security and configuration requirements for version 1.0.2 submission.

🤖 Generated with Claude Code