### PR TITLE
Fix ITMS-90546: Configure Assets.xcassets as compilable asset catalog

### DIFF
--- a/tibok/project.yml
+++ b/tibok/project.yml
@@ -30,7 +30,7 @@ targets:
           - Resources/IconLayers
     resources:
       - path: tibok/Resources/Assets.xcassets
-        type: folder
+        type: file
       - path: tibok/Resources/AppIcon.icns
         type: file
       - path: tibok/Resources/katex

--- a/tibok/tibok/Resources/Info-AppStore.plist
+++ b/tibok/tibok/Resources/Info-AppStore.plist
@@ -32,7 +32,7 @@
 	<key>CFBundleIconFile</key>
 	<string>icon</string>
 	<key>CFBundleIconName</key>
-	<string>icon</string>
+	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>app.tibok.editor</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
- Change Assets.xcassets resource type from 'folder' to 'file' in project.yml This enables XcodeGen to properly recognize it as an asset catalog that should be compiled by Xcode's actool, generating Assets.car for the bundle

- Update CFBundleIconName in Info.plist from 'icon' to 'AppIcon' Ensure consistency with ASSETCATALOG_COMPILER_APPICON_NAME setting in project.yml

These changes fix the ITMS-90546 error "Missing asset catalog" that was preventing Xcode Cloud builds from being accepted by App Store Connect.

🤖 Generated with Claude Code