### PR TITLE
Fix App Store rejection: remove entitlement exception, add Window menu

### DIFF
--- a/tibok/tibok/Resources/tibok-appstore.entitlements
+++ b/tibok/tibok/Resources/tibok-appstore.entitlements
@@ -2,13 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>F2PFRMGC9V.com.kquinones.tibok</string>
 	</array>
-	<key>com.apple.security.temporary-exception.files.absolute-path.read-only</key>
-	<array>
-		<string>$(HOME)</string>
-	</array>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
- Remove com.apple.security.temporary-exception.files.absolute-path.read-only from App Store entitlements (Guideline 2.4.5(i))
- Add Window > Main Window menu item to reopen closed window (Guideline 4)
- Add AppDelegate to handle dock icon click when no windows visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)