### PR TITLE
Update window management and app sandboxing.

### DIFF
--- a/tibok/tibok/Resources/tibok-appstore.entitlements
+++ b/tibok/tibok/Resources/tibok-appstore.entitlements
@@ -2,13 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>F2PFRMGC9V.com.kquinones.tibok</string>
 	</array>
-	<key>com.apple.security.temporary-exception.files.absolute-path.read-only</key>
-	<array>
-		<string>$(HOME)</string>
-	</array>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request introduces significant improvements to window management and app sandboxing in the `tibok` macOS app. The changes enhance how the main window is reopened, improve SwiftUI integration with AppKit for window control, and update the app's entitlements for better security and user file access.

**Window management and SwiftUI/AppKit integration:**

* Added a new `MainWindowContent` SwiftUI view and refactored the main window scene to use it, enabling better control over window actions and capturing the `openWindow` environment action for use outside SwiftUI. [[1]](diffhunk://#diff-e0b832d1549938adb63b2087ea881763b54acd65a8ab6969b5e20d683ab81ceaL41-R43) [[2]](diffhunk://#diff-e0b832d1549938adb63b2087ea881763b54acd65a8ab6969b5e20d683ab81ceaR808-R882)
* Introduced an `AppDelegate` class to handle dock icon clicks, allowing the app to reopen the main window when all windows are closed. [[1]](diffhunk://#diff-e0b832d1549938adb63b2087ea881763b54acd65a8ab6969b5e20d683ab81ceaR14) [[2]](diffhunk://#diff-e0b832d1549938adb63b2087ea881763b54acd65a8ab6969b5e20d683ab81ceaR808-R882)
* Implemented a `reopenMainWindow()` function and a `WindowAccessor` singleton to bridge SwiftUI and AppKit for window reopening, including a new "Main Window" menu item with a keyboard shortcut. [[1]](diffhunk://#diff-e0b832d1549938adb63b2087ea881763b54acd65a8ab6969b5e20d683ab81ceaL372-R381) [[2]](diffhunk://#diff-e0b832d1549938adb63b2087ea881763b54acd65a8ab6969b5e20d683ab81ceaR808-R882)

**App sandboxing and entitlements:**

* Updated `tibok-appstore.entitlements` to enable app sandboxing, allow user-selected file read/write access, and permit network client access, removing the previous temporary file access exception.

**Other UI and command improvements:**

* Refactored command groups to organize menu items, including separating the Find menu and adding a dedicated command for reopening the main window. [[1]](diffhunk://#diff-e0b832d1549938adb63b2087ea881763b54acd65a8ab6969b5e20d683ab81ceaL66-R66) [[2]](diffhunk://#diff-e0b832d1549938adb63b2087ea881763b54acd65a8ab6969b5e20d683ab81ceaL372-R381)